### PR TITLE
fix(SAFE-T1004): replace placeholder guidance and add rule tests

### DIFF
--- a/techniques/SAFE-T1004/README.md
+++ b/techniques/SAFE-T1004/README.md
@@ -1,107 +1,97 @@
-
 # SAFE-T1004: Server Impersonation / Name-Collision
 
 ## Overview
-
 **Tactic**: Credential Access (ATK-TA0006), Initial Access (ATK-TA0001)  
 **Technique ID**: SAFE-T1004  
 **Severity**: High  
-**First Observed**: Documented in DNS cache poisoning attacks (Kaminsky, 2008)  
-**Last Updated**: November 2025  
+**First Observed**: Documented in DNS cache poisoning attacks (2008)  
+**Last Updated**: 2026-02-24
 
 ## Description
+Server Impersonation / Name-Collision is an adversary-in-the-middle technique where attackers register or advertise a malicious server using the same name or identifier as a trusted one. By exploiting weaknesses in naming and discovery systems (for example DNS, mDNS, or local MCP server registries), clients can be redirected to attacker-controlled endpoints.
 
-Server Impersonation / Name-Collision is an adversary-in-the-middle technique where attackers register or advertise a malicious server using the same name or identifier as a trusted one. By exploiting weaknesses in naming systems (DNS, mDNS, or MCP’s On-Device Agent Registry), clients are tricked into connecting to the attacker-controlled endpoint.
+This technique is dangerous in MCP environments because trust decisions are often made before strong identity checks. If clients accept duplicated names, unsigned metadata, or weak certificates, an attacker can intercept authentication flows, alter tool responses, and capture sensitive data.
 
-### What is ODR?
-
-The **On‑Device Agent Registry (ODR)** is a Windows component of the **Model Context Protocol (MCP)**. It acts as a secure local registry where MCP servers and connectors are registered so that AI agents and applications can automatically discover them in a standardized way.  Contains metadata, endpoints and certificates.
+### Registry Context (ODR / Local Registry)
+In this technique, **ODR** refers to host-local discovery or registry layers used by MCP host applications to store server metadata (name, endpoint, and trust attributes). On Windows, this concept aligns with the On-Device Agent Registry tooling (`odr.exe`) for MCP server registration and discovery. Implementations vary by platform and product; if your environment does not use ODR by name, apply the same controls to its equivalent local registry/discovery mechanism.
 
 ## Attack Vectors
-
-- **Primary Vector**: Malicious server registration with identical name/URL in DNS, mDNS, or ODR  
-- **Secondary Vectors**:  
-  - DNS cache poisoning or hijacking  
-  - Rogue DHCP servers distributing malicious DNS settings
-  - ODR Poisoning
-  - Certificate misuse / Weak validation
-  - Service Redeployment windows
-  - ARP (Address Resolution Protocol) cache poisoning
+- **Primary Vector**: Malicious server registration with a trusted server's name or identifier
+- **Secondary Vectors**:
+  - DNS cache poisoning or DNS hijacking
+  - Rogue DHCP infrastructure distributing attacker-controlled DNS settings
+  - Duplicate local registry entries for an existing trusted server
+  - TLS certificate misuse, weak validation, or certificate pinning gaps
+  - ARP spoofing on local networks
+  - Service redeployment windows where identity checks are temporarily bypassed
 
 ## Technical Details
 
 ### Prerequisites
-
-- **Network Access**: Attacker must be positioned on the same network (for ARP/mDNS/DHCP poisoning) or have upstream control (for DNS hijacking).
-- **Weak Discovery Protections**: DNS without DNSSEC validation; mDNS or ODR responses trusted without controls.
-- **Client Trust Assumptions**: Clients equate “name = identity” without verifying certificates or a lack of mutual TLS or certificate pinning.
-- **Legacy Protocols Enabled**: LLMNR/NBT‑NS, DHCP clients, ARP cache updates accepted are active without controls.
-- **Attacker Capabilities**: Ability to forge or inject responses, register malicious services, or impersonate trusted endpoints.
+- Attacker network position (local segment, rogue upstream DNS, or other interception path)
+- Weak discovery protections (no DNSSEC validation, permissive local registry behavior, or missing duplicate-name checks)
+- Trust model that treats name as identity without robust certificate validation
+- Ability to register or advertise a malicious endpoint with legitimate-appearing metadata
 
 ### Attack Flow
-
-1. **Initial Stage**: Attacker sets up a malicious server with the same identifier as a trusted one.  
-2. **Discovery Hijack**: Attacker poisons DNS/mDNS responses or registers duplicate entries in ODR.  
-3. **Connection Stage**: Client connects to the attacker’s server, believing it is legitimate.  
-4. **Exploitation Stage**: Attacker intercepts credentials, sensitive data, or injects malicious commands.  
-5. **Post-Exploitation**: Attacker pivots laterally using harvested credentials or maintains persistence via poisoned registry entries.  
+1. **Preparation**: Attacker deploys a malicious endpoint that mimics a trusted MCP server name.
+2. **Discovery Hijack**: DNS/mDNS responses or local registry entries are poisoned or duplicated.
+3. **Connection**: Client resolves the trusted name to the attacker endpoint and initiates session setup.
+4. **Impersonation**: Attacker presents weak or mismatched identity material and intercepts traffic.
+5. **Exploitation**: Credentials, tokens, and sensitive data are harvested; malicious responses may be injected.
+6. **Post-Exploitation**: Attacker persists through registry poisoning and can pivot to additional systems.
 
 ### Example Scenario
-
 ```json
-// Example malicious ODR registration
 {
   "service_name": "analytics-hub.local",
   "endpoint": "192.168.1.50",
-  "certificate": "self-signed"
+  "certificate_fingerprint": "untrusted-self-signed",
+  "source": "local-registry"
 }
 ```
 
 ### Advanced Attack Techniques (Research Published)
+According to public reporting and ATT&CK campaign tracking, attackers use multiple identity-hijack layers:
 
-According to research from [Kaminsky, 2008](https://en.wikipedia.org/wiki/Dan_Kaminsky) and [Sea Turtle Campaign, 2019](https://attack.mitre.org/campaigns/C0022/), attackers have developed sophisticated variations:
+1. **DNS Cache Poisoning**: False DNS responses direct clients to malicious infrastructure.
+2. **Registrar Hijacking**: Domain and DNS control are taken over to reroute traffic at scale (for example [Sea Turtle / G1041](https://attack.mitre.org/groups/G1041/)).
+3. **Hybrid Discovery Poisoning**: DNS hijack combined with local network attacks (ARP/DHCP) to increase reliability and evade single-layer controls.
 
-1. **DNS Cache Poisoning**: Injecting false records into resolvers to redirect traffic (Kaminsky, 2008).  
-2. **Registrar Hijacking**: Compromising DNS registrars to reroute traffic at scale (Sea Turtle, 2019). 
-3. **Chained Attacks (Hybrid Poisoning)**: Combining multiple attacks into a single attack vector for greater impact (Kaminsky, 2019).
- 
 ## Impact Assessment
+- **Confidentiality**: High - credentials and sensitive data can be intercepted.
+- **Integrity**: High - malicious responses can alter workflow outputs and decisions.
+- **Availability**: Medium - service resolution failures and trust breaks can interrupt operations.
+- **Scope**: Network-wide - affects any client relying on poisoned discovery/identity signals.
 
-- **Confidentiality**: High – Credentials and sensitive data can be intercepted.  
-- **Integrity**: High – Malicious responses can alter system behavior.  
-- **Availability**: Medium – Services may be disrupted by impersonation.  
-- **Scope**: Network-wide – Affects all clients relying on poisoned discovery.  
-
-### Current Status (2025)
-
-DNSSEC adoption is increasing globally, and MCP’s ODR is evolving with new security features, but deployment remains uneven. According to security researchers, organizations are beginning to implement certificate pinning and mutual TLS in MCP environments.
-
-- **DNSSEC** is being actively adopted, with Microsoft and EU regulators pushing for stronger protections ([Internet Society – DNSSEC Deployment Maps](https://www.internetsociety.org/deploy360/dnssec/maps/)).  
-- **Global adoption remains partial** — less than half of DNS queries are validated, leaving room for cache poisoning and hijacking ([European Commission JRC Report on DNSSEC Adoption (2025)](https://publications.jrc.ec.europa.eu/repository/handle/JRC143100)).  
-- **MCP’s ODR** is evolving, but organizations should already enforce **certificate pinning, signed entries, and monitoring for duplicates** to mitigate impersonation risks ([Model Context Protocol Roadmap (Oct 2025)](https://modelcontextprotocol.io/development/roadmap)).  
+### Current Status (2026)
+Organizations are increasingly prioritizing stronger discovery and identity controls, but coverage remains uneven:
+- DNSSEC adoption continues to expand, but not all enterprise resolvers and zones validate consistently.
+- MCP roadmap work includes stronger server identity/discovery signals through `.well-known` metadata endpoints.
+- Teams with mixed legacy protocols and inconsistent registry governance remain exposed to name-collision attacks.
 
 ## Detection Methods
 
 ### Indicators of Compromise (IoCs)
-
-- **DNS/Name resolution** anomalies such as unexpected, unknown, or unsigned requests with frequent cache updates
-- **ODR** anomalies such as unexpected changes, duplicate services, or unsigned requests
-- **ARP** anomalies such as frequent changes or duplicate entries
-- **DHCP** anomalies such as new leases or multiple servers
-- **TLS / Certificate** anomalies such as handshake failure, unknown or self signed certificates
-- **Traffic Pattern** anomalies such as sensitive data flows, auth failure spikes, known attacker infrastructure requests
+- Sudden DNS resolution drift for trusted MCP server names
+- Duplicate or conflicting server entries in local MCP registries
+- ARP anomalies and MAC/IP mismatch events around MCP traffic
+- TLS certificate mismatch or unexpected self-signed certificate acceptance
+- Authentication failures and suspicious reconnect loops after resolution changes
 
 ### Detection Rules
+**Important**: The following Sigma-style rule is an example. Organizations should tailor fields and event IDs to their telemetry pipeline and operating system logging configuration.
 
 ```yaml
 title: Detection of Server Impersonation / Name-Collision (SAFE-T1004)
 id: 9f3c2a8e-7d4b-4c2f-9a1e-8e2b7f9c1d23
 status: experimental
-description: Detects indicators of server impersonation or name-collision attacks across DNS, ARP, and ODR
-author: Ryan
+description: Detects indicators of server impersonation or name-collision attacks across DNS, ARP, TLS, and local registry events
+author: Ryan Jennings
 date: 2025-11-22
+modified: 2026-02-24
 references:
-  - https://github.com/safe-mcp/techniques/SAFE-T1004
+  - https://github.com/SAFE-MCP/safe-mcp/tree/main/techniques/SAFE-T1004
   - https://attack.mitre.org/techniques/T1557/
   - https://attack.mitre.org/techniques/T1565/002/
 logsource:
@@ -112,12 +102,14 @@ detection:
     EventID: 1014
     Provider_Name: "Microsoft-Windows-DNS-Client"
     Message|contains:
-      - "resolved to unexpected IP"
+      - "timed out after none of the configured DNS servers responded"
       - "DNSSEC validation failed"
   selection_odr:
-    service_name|count: ">1"   # duplicate service names in ODR
+    Provider_Name: "ODR"
+    Message|contains:
+      - "duplicate service registration"
+      - "name collision"
   selection_arp:
-    EventID: 2022
     Provider_Name: "Microsoft-Windows-TCPIP"
     Message|contains:
       - "duplicate ARP entry"
@@ -130,98 +122,78 @@ detection:
       - "self-signed certificate"
   condition: selection_dns or selection_odr or selection_arp or selection_tls
 falsepositives:
-  - Legitimate redeployment of services causing duplicate names
-  - Test environments with self-signed certificates
+  - Legitimate service redeployments that temporarily create duplicate registry entries
+  - Controlled test environments using self-signed certificates
+  - Planned DNS cutovers during maintenance windows
 level: high
 tags:
   - attack.credential_access
   - attack.t1557
-  - attack.t1565.002
   - attack.t1557.002
+  - attack.t1565.002
   - safe.t1004
 ```
 
 ### Behavioral Indicators
-
-- Duplicate service names in ODR  
-- Unexpected ODR changes — new MCP services appearing
-- Clients connecting to endpoints outside expected IP ranges
-- Sudden changes in DNS resolution for trusted domains
-- Frequent DNS cache flushes or anomalies
-- Unsigned DNS responses where DNSSEC validation should be present
-- Multiple conflicting DNS responses for the same query
-- TLS handshake failures due to certificate mismatches
-- Clients accepting self‑signed certificates
-- Frequent or duplicate ARP table changes
-- New DHCP leases assigning DNS servers
-- Sudden spikes in authentication failures
-- Outbound traffic to attacker infrastructure
-- Clients connecting to unexpected IP ranges  
-- Multiple mDNS responses for the same hostname 
+- New duplicate service names for trusted MCP endpoints
+- Increased DNS cache refreshes and resolver warning events for previously stable names
+- Clients connecting to unexpected IP ranges for known servers
+- TLS handshake failures or fallback behavior after certificate mismatches
+- Correlated ARP anomalies near authentication or token exchange failures
 
 ## Mitigation Strategies
 
 ### Preventive Controls
-
-1. **[SAFE-M-000: Mutual TLS](../../mitigations/SAFE-M-000/README.md)**: Enforce mutual authentication between clients and servers.  
-2. **[SAFE-M-000: DNSSEC](../../mitigations/SAFE-M-000/README.md)**: Validate DNS records cryptographically.  
-3. **[SAFE-M-000: Registry Hardening](../../mitigations/SAFE-M-000/README.md)**: Require signed entries in ODR and enforce unique identifiers.  
-4. **[SAFE-M-000: Disable Legacy Protocols](../../mitigations/SAFE-M-000/README.md)**: Disable LLMNR/NBT‑NS and ARP where possible.  
-5. **[SAFE-M-000: Network Segmentation](../../mitigations/SAFE-M-000/README.md)**: Isolate critical MCP servers and DNS infrastructure from general user subnets.  
+1. **[SAFE-M-14: Server Allowlisting](../../mitigations/SAFE-M-14/README.md)**: Restrict MCP connections to explicit trusted domains/endpoints.
+2. **[SAFE-M-2: Cryptographic Integrity for Tool Descriptions](../../mitigations/SAFE-M-2/README.md)**: Sign and verify tool metadata to reduce tampering and spoofing risk.
+3. **[SAFE-M-6: Tool Registry Verification](../../mitigations/SAFE-M-6/README.md)**: Enforce trusted registry source controls and signature validation.
+4. **[SAFE-M-45: Tool Manifest Signing & Server Attestation](../../mitigations/SAFE-M-45/README.md)**: Validate server identity and manifest integrity before accepting tools.
+5. **[SAFE-M-29: Explicit Privilege Boundaries](../../mitigations/SAFE-M-29/README.md)**: Limit blast radius if a spoofed endpoint is accepted.
 
 ### Detective Controls
-
-1. **[SAFE-M-000: Duplicate Name Monitoring](../../mitigations/SAFE-M-000/README.md)**: Alert on duplicate service names in ODR.  
-2. **[SAFE-M-000: DNS Anomaly Detection](../../mitigations/SAFE-M-000/README.md)**: Detect sudden resolution changes for trusted domains.  
-3. **[SAFE-M-000: ARP/DHCP Monitoring](../../mitigations/SAFE-M-000/README.md)**: Detect duplicate servers and suspicious ARP entries.  
-4. **[SAFE-M-000: Certificate Validation Logs](../../mitigations/SAFE-M-000/README.md)**: Detect clients accepting untrusted or self‑signed certificates.  
+1. **[SAFE-M-12: Audit Logging](../../mitigations/SAFE-M-12/README.md)**: Log registry changes, server identity decisions, and endpoint shifts.
+2. **[SAFE-M-20: Anomaly Detection](../../mitigations/SAFE-M-20/README.md)**: Detect unexpected discovery/connection behavior and resolution drift.
+3. **[SAFE-M-11: Behavioral Monitoring](../../mitigations/SAFE-M-11/README.md)**: Correlate unusual tool behavior with identity and routing anomalies.
 
 ### Response Procedures
-
-1. **Immediate Actions**:  
-   - Block malicious IPs at the firewall  
-   - Remove rogue ODR entries  
-   - Flush poisoned DNS/ARP caches on affected hosts  
-
-2. **Investigation Steps**:  
-   - Review DNS logs, ODR audit trails, and ARP tables  
-   - Identify compromised accounts or systems  
-
-3. **Remediation**:  
-   - Rotate exposed credentials  
-   - Patch discovery protocols  
-   - Enforce secure registration  
-   - Deploy long‑term monitoring for anomalies  
+1. **Immediate Actions**:
+   - Block malicious or untrusted endpoint IPs/domains.
+   - Remove rogue local registry entries and disable affected server registrations.
+   - Flush poisoned DNS and ARP caches on impacted hosts.
+2. **Investigation Steps**:
+   - Reconstruct timeline of DNS/registry/certificate changes.
+   - Identify initial poisoning vector (DNS, ARP, DHCP, registry tampering).
+   - Scope impacted clients and exposed credentials/tokens.
+3. **Remediation**:
+   - Rotate exposed credentials, tokens, and certificates.
+   - Re-establish trusted server identity material and pinning policy.
+   - Add preventive and detective controls for duplicate-name and identity drift.
 
 ## Related Techniques
-
-- [SAFE‑T1001](../SAFE-T1001/) – DNS Cache Poisoning
-- [SAFE-T1002](../SAFE-T1002/): DNS Manipulation – closely related to impersonation via poisoned records.  
-- [SAFE-T1003](../SAFE-T1003/): Adversary-in-the-Middle – broader category encompassing impersonation attacks.
-- [SAFE-T1402](../SAFE-T1402/): Instruction Stenography for registry manipulation 
+- [SAFE-T1301](../SAFE-T1301/README.md): Cross-Server Tool Shadowing - exploits tool-name collisions in multi-server environments.
+- [SAFE-T1407](../SAFE-T1407/README.md): Server Proxy Masquerade - uses intermediary infrastructure to impersonate trusted paths.
+- [SAFE-T1005](../SAFE-T1005/README.md): Exposed Endpoint Exploit - broad endpoint exposure can enable impersonation opportunities.
+- [SAFE-T1704](../SAFE-T1704/README.md): Compromised-Server Pivot - impersonation can provide a foothold for lateral movement.
 
 ## References
-
-- [Model Context Protocol Specification](https://modelcontextprotocol.io/specification)  
-- [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)  
-- [Kaminsky DNS Cache Poisoning - 2008](https://en.wikipedia.org/wiki/Dan_Kaminsky)  
-- [Sea Turtle DNS Hijacking Campaign - 2019](https://attack.mitre.org/campaigns/C0022/)  
-- [Microsoft 365 DNS Provisioning Change – DNSSEC Adoption](https://mc.merill.net/message/MC1048624)  
-- [Internet Society – DNSSEC Deployment Maps](https://www.internetsociety.org/deploy360/dnssec/maps/)  
-- [Model Context Protocol Roadmap (Oct 2025)](https://modelcontextprotocol.io/development/roadmap)  
-- [M365 Admin DNSSEC Provisioning Change](https://d365hub.com/Posts/Details/ce776f51-54d3-42d5-a97f-b8537eef4fb4/dns-provisioning-change)  
-- [European Commission JRC Report on DNSSEC Adoption (2025)](https://publications.jrc.ec.europa.eu/repository/handle/JRC143100)  
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/specification)
+- [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [Sea Turtle - ATT&CK Group G1041](https://attack.mitre.org/groups/G1041/)
+- [Windows ODR Tool (odr.exe)](https://learn.microsoft.com/en-us/windows/ai/mcp/odr-tool)
+- [Internet Society - DNSSEC Deployment Maps](https://www.internetsociety.org/deploy360/dnssec/maps/)
+- [APNIC DNSSEC Validation World Map](https://stats.labs.apnic.net/dnssec)
+- [European Commission JRC Report on DNSSEC Adoption (2025)](https://publications.jrc.ec.europa.eu/repository/handle/JRC143100)
+- [Model Context Protocol Roadmap](https://modelcontextprotocol.io/development/roadmap)
 
 ## MITRE ATT&CK Mapping
-
-- [T1557 – Adversary-in-the-Middle](https://attack.mitre.org/techniques/T1557/)  
-- [T1565.002 – Data Manipulation: DNS Manipulation](https://attack.mitre.org/techniques/T1565/002/)  
-- [T1071.004 – Application Layer Protocol: DNS](https://attack.mitre.org/techniques/T1071/004/)
-- [T1112 - Modify Registry](https://attack.mitre.org/techniques/T1112/)
-- [T1565 - Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+- [T1557 - Adversary-in-the-Middle](https://attack.mitre.org/techniques/T1557/)
+- [T1557.002 - Adversary-in-the-Middle: ARP Cache Poisoning](https://attack.mitre.org/techniques/T1557/002/)
+- [T1565.002 - Data Manipulation: DNS Manipulation](https://attack.mitre.org/techniques/T1565/002/)
+- [T1071.004 - Application Layer Protocol: DNS](https://attack.mitre.org/techniques/T1071/004/)
 
 ## Version History
-
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
 | 1.0 | 2025-11-22 | Initial documentation with ODR explanation | Ryan Jennings |
+| 1.1 | 2026-02-24 | Replaced placeholder mitigations, corrected related-technique mapping, updated detection rule example, and added clearer ODR scope language | Bishnu Bista |
+| 1.2 | 2026-02-24 | Corrected ATT&CK reference for Sea Turtle, aligned DNS EventID 1014 example wording, reduced over-specific ARP event assumptions, and added ODR/APNIC references for source clarity | Bishnu Bista |

--- a/techniques/SAFE-T1004/detection-rule.yml
+++ b/techniques/SAFE-T1004/detection-rule.yml
@@ -1,11 +1,12 @@
 title: Detection of Server Impersonation / Name-Collision (SAFE-T1004)
 id: 9f3c2a8e-7d4b-4c2f-9a1e-8e2b7f9c1d23
 status: experimental
-description: Detects indicators of server impersonation or name-collision attacks across DNS, ARP, and ODR
+description: Detects indicators of server impersonation or name-collision attacks across DNS, ARP, TLS, and local registry events
 author: Ryan Jennings
 date: 2025-11-22
+modified: 2026-02-24
 references:
-  - https://github.com/safe-mcp/techniques/SAFE-T1004
+  - https://github.com/SAFE-MCP/safe-mcp/tree/main/techniques/SAFE-T1004
   - https://attack.mitre.org/techniques/T1557/
   - https://attack.mitre.org/techniques/T1565/002/
 logsource:
@@ -16,12 +17,14 @@ detection:
     EventID: 1014
     Provider_Name: "Microsoft-Windows-DNS-Client"
     Message|contains:
-      - "resolved to unexpected IP"
+      - "timed out after none of the configured DNS servers responded"
       - "DNSSEC validation failed"
   selection_odr:
-    service_name|count: ">1"   # duplicate service names in ODR
+    Provider_Name: "ODR"
+    Message|contains:
+      - "duplicate service registration"
+      - "name collision"
   selection_arp:
-    EventID: 2022
     Provider_Name: "Microsoft-Windows-TCPIP"
     Message|contains:
       - "duplicate ARP entry"
@@ -34,12 +37,13 @@ detection:
       - "self-signed certificate"
   condition: selection_dns or selection_odr or selection_arp or selection_tls
 falsepositives:
-  - Legitimate redeployment of services causing duplicate names
-  - Test environments with self-signed certificates
+  - Legitimate service redeployments that temporarily create duplicate registry entries
+  - Controlled test environments using self-signed certificates
+  - Planned DNS cutovers during maintenance windows
 level: high
 tags:
   - attack.credential_access
   - attack.t1557
-  - attack.t1565.002
   - attack.t1557.002
+  - attack.t1565.002
   - safe.t1004

--- a/techniques/SAFE-T1004/test-logs.json
+++ b/techniques/SAFE-T1004/test-logs.json
@@ -2,31 +2,61 @@
   {
     "EventID": 1014,
     "Provider_Name": "Microsoft-Windows-DNS-Client",
-    "Message": "Domain api.company.com resolved to unexpected IP 192.168.1.50"
+    "Message": "Name resolution for the name api.company.com timed out after none of the configured DNS servers responded.",
+    "expected_detection": true
   },
   {
     "EventID": 1014,
     "Provider_Name": "Microsoft-Windows-DNS-Client",
-    "Message": "DNSSEC validation failed for domain secure.company.com"
+    "Message": "DNSSEC validation failed for domain secure.company.com",
+    "expected_detection": true
+  },
+  {
+    "EventID": 1014,
+    "Provider_Name": "Microsoft-Windows-DNS-Client",
+    "Message": "Domain api.company.com resolved to known IP 10.0.0.15",
+    "expected_detection": false
   },
   {
     "EventID": 2022,
     "Provider_Name": "Microsoft-Windows-TCPIP",
-    "Message": "Duplicate ARP entry detected for 192.168.1.1 with MAC aa-bb-cc-dd-ee-ff"
+    "Message": "Duplicate ARP entry detected for 192.168.1.1 with MAC aa-bb-cc-dd-ee-ff",
+    "expected_detection": true
+  },
+  {
+    "EventID": 2022,
+    "Provider_Name": "Microsoft-Windows-TCPIP",
+    "Message": "ARP cache updated for gateway 192.168.1.1",
+    "expected_detection": false
   },
   {
     "EventID": 36882,
     "Provider_Name": "Schannel",
-    "Message": "TLS certificate mismatch detected for service analytics-hub.local"
+    "Message": "TLS certificate mismatch detected for service analytics-hub.local",
+    "expected_detection": true
   },
   {
     "EventID": 36882,
     "Provider_Name": "Schannel",
-    "Message": "Client accepted self-signed certificate for endpoint 192.168.1.50"
+    "Message": "TLS handshake completed with trusted certificate",
+    "expected_detection": false
   },
   {
     "EventID": 9999,
     "Provider_Name": "ODR",
-    "Message": "Duplicate service registration detected: analytics-hub.local"
+    "Message": "Duplicate service registration detected: analytics-hub.local",
+    "expected_detection": true
+  },
+  {
+    "EventID": 9999,
+    "Provider_Name": "ODR",
+    "Message": "Name collision detected for service analytics-hub.local",
+    "expected_detection": true
+  },
+  {
+    "EventID": 9999,
+    "Provider_Name": "ODR",
+    "Message": "Service registration refreshed for analytics-hub.local",
+    "expected_detection": false
   }
 ]

--- a/techniques/SAFE-T1004/test_detection_rule.py
+++ b/techniques/SAFE-T1004/test_detection_rule.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validation script for SAFE-T1004 detection rule."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+
+def load_rule_and_logs() -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    base = Path(__file__).parent
+    rule = yaml.safe_load((base / "detection-rule.yml").read_text())
+    logs = json.loads((base / "test-logs.json").read_text())
+    return rule, logs
+
+
+def _matches_field(log_entry: Dict[str, Any], key: str, expected: Any) -> bool:
+    if "|contains" in key:
+        field = key.split("|", 1)[0]
+        value = str(log_entry.get(field, "")).lower()
+        terms = expected if isinstance(expected, list) else [expected]
+        return any(str(term).lower() in value for term in terms)
+
+    actual = log_entry.get(key)
+    if isinstance(expected, list):
+        return actual in expected
+    return actual == expected
+
+
+def _matches_selection(log_entry: Dict[str, Any], selection: Dict[str, Any]) -> bool:
+    return all(_matches_field(log_entry, key, expected) for key, expected in selection.items())
+
+
+def evaluate_log(log_entry: Dict[str, Any], detection: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    matched = []
+    for name, selection in detection.items():
+        if not name.startswith("selection_"):
+            continue
+        if _matches_selection(log_entry, selection):
+            matched.append(name)
+    return bool(matched), matched
+
+
+def test_detection_rule() -> bool:
+    rule, logs = load_rule_and_logs()
+    detection = rule["detection"]
+
+    print("SAFE-T1004 Detection Rule Test Results")
+    print("=" * 60)
+
+    passed = 0
+    for idx, log_entry in enumerate(logs, start=1):
+        expected = bool(log_entry.get("expected_detection"))
+        detected, matched = evaluate_log(log_entry, detection)
+        ok = detected == expected
+        if ok:
+            passed += 1
+        status = "✓" if ok else "✗"
+        print(f"{status} case_{idx}: detected={detected}, expected={expected}, matched={matched}")
+
+    total = len(logs)
+    print("=" * 60)
+    print(f"Test Summary: {passed}/{total} tests passed ({(passed / total) * 100:.1f}%)")
+
+    return passed == total
+
+
+if __name__ == "__main__":
+    success = test_detection_rule()
+    raise SystemExit(0 if success else 1)


### PR DESCRIPTION
## Summary

Harden SAFE-T1004 technique documentation, detection rule, and test coverage:
- Rewrite README to remove placeholder mitigations and incorrect related-technique mappings
- Update detection rule to use actionable ODR matching and valid SAFE-MCP reference URLs
- Relax unsupported ARP event-id assumption in detection logic
- Expand test logs with positive/negative cases
- Add runnable `test_detection_rule.py` validation script

## Type of Contribution

- [ ] New Technique
- [ ] New Mitigation
- [x] Update to existing content
- [x] Documentation improvement

## Checklist

- [x] DCO sign-off included in commits (`git commit -s`)
- [x] For technique contributions: see [TEMPLATE-CHECKLIST.md](techniques/TEMPLATE-CHECKLIST.md)
- [ ] For mitigation contributions: see [TEMPLATE-CHECKLIST.md](mitigations/TEMPLATE-CHECKLIST.md)

## Validation

- `python3 techniques/SAFE-T1004/test_detection_rule.py`
- Parsed `techniques/SAFE-T1004/detection-rule.yml` with `yaml.safe_load`
- Checked relative links in `techniques/SAFE-T1004/README.md`

## Related Issues

N/A