### PR TITLE
feat(mitigations): add SAFE-M-69/70/71/72 for tool-invocation controls

### DIFF
--- a/mitigations/SAFE-M-69/README.md
+++ b/mitigations/SAFE-M-69/README.md
@@ -1,10 +1,10 @@
 # SAFE-M-69: Out-of-Band Authorization for Privileged Tool Invocations
 
 ## Overview
-**Mitigation ID**: SAFE-M-69
-**Category**: Preventive Control (Architectural)
-**Effectiveness**: High
-**Implementation Complexity**: Medium-High
+**Mitigation ID**: SAFE-M-69  
+**Category**: Preventive Control (Architectural)  
+**Effectiveness**: High  
+**Implementation Complexity**: Medium-High  
 **First Published**: 2026-04-14
 
 ## Description

--- a/mitigations/SAFE-M-69/README.md
+++ b/mitigations/SAFE-M-69/README.md
@@ -1,0 +1,270 @@
+# SAFE-M-69: Out-of-Band Authorization for Privileged Tool Invocations
+
+## Overview
+**Mitigation ID**: SAFE-M-69
+**Category**: Preventive Control (Architectural)
+**Effectiveness**: High
+**Implementation Complexity**: Medium-High
+**First Published**: 2026-04-14
+
+## Description
+Out-of-Band Authorization for Privileged Tool Invocations is a host-side control that requires every call to a privileged MCP tool to pass through an authorization step whose decision is made and enforced **outside the model's context window**. In-prompt assertions ("I'm the admin", "the user already approved", "we're in maintenance mode") cannot, on their own, satisfy the check. Instead, a distinct authorization channel — a human-in-the-loop confirmation UI, a policy engine, a signed short-lived capability token, or an approval message routed through a separate service such as Slack, email, or an incident-ticket workflow — must produce an explicit, verifiable grant before the MCP host dispatches the tool call.
+
+The control addresses the failure mode in which a prompt-manipulated agent decides to invoke a privileged tool and the host executes the call without any independent check. By moving the authorization boundary off the model-reachable surface, SAFE-M-69 makes the privileged-invocation decision resistant to natural-language coercion: even a fully compromised model context cannot produce the approval artifact, because the approval is issued by a principal or a service the model cannot impersonate. This mitigation is the load-bearing tool-invocation-time control for SAFE-T1309 (Privileged Tool Invocation via Prompt Manipulation); it composes with, but is distinct from, static allowlisting or privilege-tier definitions.
+
+## Mitigates
+- [SAFE-T1309](../../techniques/SAFE-T1309/README.md): Privileged Tool Invocation via Prompt Manipulation
+- [SAFE-T1104](../../techniques/SAFE-T1104/README.md): Over-Privileged Tool Abuse
+
+## Technical Implementation
+
+### Core Principles
+1. **Authorization outside the context window**: The check that gates a privileged tool call must be evaluated by code or a human the model cannot reach, prompt, or speak for. An LLM saying "I will only run this with approval" is not out-of-band authorization; the enforcement must exist in the host, not in the model.
+2. **Fail closed**: In the absence of a valid, unexpired, scope-matching authorization artifact, the invocation is denied. Missing or malformed approvals never default to "allow".
+3. **Bind the grant to the call**: The authorization artifact (signed token, approval record, confirmation click) must reference the specific tool, the specific arguments (or a digest of them), the requesting session, and a short expiry. A generic "the user is logged in" session flag is insufficient.
+4. **Privilege derives from session identity, not from arguments or prose**: The caller's right to request approval is determined by the authenticated session's role, not by text the model emitted or the user typed into the prompt.
+5. **Auditable**: Every grant, denial, and timeout is logged with the full request context so that post-incident review can reconstruct who approved what and when.
+
+### Architecture Components
+```
++---------------------+        proposed tool call         +-------------------------+
+|      LLM / Agent    | --------------------------------> |        MCP Host         |
+| (reasoning, text)   |    {tool, args, session_id}       |  (tool dispatch layer)  |
++---------------------+                                   +-----------+-------------+
+                                                                      |
+                                                   privileged?        | yes
+                                                                      v
+                                              +---------------------------------------+
+                                              |  OOB Authorization Gate (out-of-band) |
+                                              |---------------------------------------|
+                                              |  - policy engine check                |
+                                              |  - capability-token verification      |
+                                              |  - human confirmation UI prompt       |
+                                              |  - approval via Slack / email / ticket|
+                                              +-----+----------------+---------+------+
+                                                    |                |         |
+                                           grant    | deny   timeout |         | reviewer
+                                                    v                v         v
+                                            +----------------+  +-------------------+
+                                            | Tool Execution |  | Denied + Audited  |
+                                            | (MCP server)   |  | (no dispatch)     |
+                                            +----------------+  +-------------------+
+
+Legend:
+  - The model can observe that approval was requested but cannot forge the grant.
+  - The grant artifact is produced by a principal/service outside the model's reach.
+  - Decisions (allow/deny/timeout) are logged to an append-only audit sink.
+```
+
+### Prerequisites
+- A working classification of which tools are "privileged" and a privilege hierarchy (see [SAFE-M-29](../SAFE-M-29/README.md)). SAFE-M-29 defines the boundary (which tools are privileged, the privilege levels, and the escalation rules between them). SAFE-M-69 supplies the **per-invocation authorization artifact** that the gate checks — the capability token, human-approval signal, or out-of-band grant that the caller must present. M-29 can reference M-69 as one implementation choice for its escalation step; M-69 composes with M-29 but does not subsume it.
+- An authenticated session identity for the user on whose behalf the agent is acting (OIDC, SSO, or equivalent). In-prompt role claims are not identities.
+- A secure channel for carrying approval requests to a human or policy service (signed webhook, authenticated UI, mTLS to a policy engine).
+- Key material and rotation process if capability tokens are used (HSM- or KMS-backed signing key, short token TTLs).
+- Audit logging infrastructure capable of correlating the tool call, the approval request, and the approver's response.
+
+### Implementation Steps
+1. **Design Phase**:
+   - Inventory tools and mark each as privileged or non-privileged (coordinate with SAFE-M-29).
+   - For each privileged tool, define the required approval mode: human confirmation, policy-engine decision, capability token, or multi-party approval.
+   - Specify the binding: what fields of the tool call (tool id, argument digest, session id, expiry) the grant must cover.
+   - Decide the deny-on-timeout policy (default: deny after N seconds with an audit record).
+
+2. **Development Phase**:
+   - Implement a host-side interception point that every tool dispatch must traverse.
+   - Integrate the policy engine and/or approval UI. For capability tokens, implement issuance, signature verification, replay protection (nonce + expiry), and revocation.
+   - Ensure the model cannot observe or influence the approver's channel (the approval UI is rendered by the host, not by a tool the model can call).
+   - Emit structured audit events for request, grant, deny, timeout, and revocation.
+
+3. **Deployment Phase**:
+   - Roll out in **log-only** mode first: record what *would* have required approval without blocking, so approval-fatigue and false-positive rates can be measured.
+   - Tune the privileged-tool list and bundling rules (see Limitations: approval fatigue) before enabling enforce mode.
+   - Enable enforcement, monitor denial rates, and iterate. Treat a spike in denials as a potential ongoing SAFE-T1309 attempt.
+
+## Benefits
+- **Breaks the SAFE-T1309 coercion chain**: Since the grant is produced outside the model's context, natural-language manipulation of the model cannot forge it; the worst a compromised context can do is request approval it should not have.
+- **Composes with static controls**: Works alongside privilege-tier definitions (SAFE-M-29), server allowlisting (SAFE-M-14), and token-scope limiting (SAFE-M-16) to produce defense in depth across configuration time and invocation time.
+- **Produces forensic evidence**: Every privileged invocation yields a signed or logged approval record, which is invaluable for incident reconstruction and for regulatory audit trails.
+- **Supports graduated friction**: Low-risk privileged calls can route through a fast capability-token flow; high-risk calls can require explicit human review or multi-party approval, without changing the underlying architecture.
+
+## Limitations
+- **Approval fatigue is a real failure mode**: If users are prompted to confirm too often, they click "approve" without reading, which collapses the control's effectiveness. This is explicitly noted in the OWASP Top 10 for LLM Applications discussion of excessive agency. Mitigate by narrowing the privileged set (SAFE-M-14, SAFE-M-29), bundling related calls into a single approval, batching repetitive low-risk calls under a short-lived capability token, and designing approval UX that surfaces the distinguishing fields (path, host, SQL, dollar amount) rather than a generic "Allow this tool?" prompt.
+- **Latency and workflow friction**: Out-of-band approval adds time, especially for human-in-the-loop flows. Interactive sessions may become unusable if every call blocks on a human. Capability tokens with narrow scope and short TTL partially mitigate this by amortising the approval over a bounded session.
+- **Does not defend against a compromised host**: If the host process itself is compromised or if the approval UI is spoofed by the model through a vulnerable rendering surface (prompt-injected UI elements), the control degrades. The approval channel must not be addressable from the model's output.
+- **Relies on correct privilege classification**: A tool incorrectly marked non-privileged bypasses this control entirely. Misclassification pushes the failure mode upstream to SAFE-M-29.
+- **Possible single-point-of-failure for approvers**: Human approvers become an availability dependency. Off-hours on-call rotations and a documented break-glass procedure (with elevated logging) should be defined in advance.
+
+## Implementation Examples
+
+### Example 1: Signed, scoped, short-lived capability token
+A policy engine issues a DSSE- or JWT-style token binding the grant to a specific tool, an argument digest, a session id, and a short expiry. The MCP host verifies the token before dispatch.
+
+```python
+# Host-side verification (illustrative; use a vetted JWT/DSSE library in production)
+import hmac, hashlib, json, time
+
+# Persistent store of JTIs already consumed. Backed by Redis / DB in production;
+# must outlive the process and be shared across all host instances that verify tokens.
+_used_jtis: "set[str]" = set()
+
+def verify_capability_token(token: dict, expected: dict, public_key) -> dict:
+    """Verify a capability token and return the authenticated claims. Fail closed."""
+    # 1. Verify the cryptographic signature FIRST. Any field read before this point is
+    #    attacker-controllable; only `payload` + `signature` are trustworthy as inputs.
+    verify_signature(token["payload"], token["signature"], public_key)  # raises on failure
+
+    # 2. Parse claims from the verified payload. Do not trust any unsigned top-level field.
+    claims = json.loads(token["payload"])
+
+    if claims.get("ver") != 1:
+        raise PermissionError("unsupported token version")
+
+    # 3. Replay protection: every token carries a unique `jti` and a short-lived `nonce`
+    #    bound into the signed claims. Consume the jti exactly once.
+    jti = claims["jti"]
+    if jti in _used_jtis:
+        raise PermissionError("token replay detected")
+    if claims["exp"] < int(time.time()):
+        raise PermissionError("token expired")
+
+    # 4. Bind the token to the concrete call being dispatched.
+    if claims["tool"] != expected["tool"]:
+        raise PermissionError("tool mismatch")
+    if claims["session_id"] != expected["session_id"]:
+        raise PermissionError("session mismatch")
+    args_digest = hashlib.sha256(
+        json.dumps(expected["arguments"], sort_keys=True).encode()
+    ).hexdigest()
+    if not hmac.compare_digest(claims["args_digest"], args_digest):
+        raise PermissionError("arguments do not match signed grant")
+
+    _used_jtis.add(jti)  # only after every other check passes
+    return claims
+
+def dispatch_privileged_tool(call, token, public_key):
+    verify_capability_token(token, expected={
+        "tool": call.tool,
+        "session_id": call.session_id,
+        "arguments": call.arguments,
+    }, public_key=public_key)
+    return execute_tool(call)  # only reached on successful verification
+```
+
+Key properties: the token is issued by a service the model cannot reach; the arguments digest binds the grant to the exact call; the short `exp` limits replay; `verify_signature` failing closes the path.
+
+### Example 2: Human-in-the-loop confirmation UX (host-rendered)
+The host renders an approval dialog directly in the user's UI — not via a tool the model can call — and shows the tool, the exact arguments, and the session context.
+
+```text
++-----------------------------------------------------------+
+| Privileged action requested                               |
+|-----------------------------------------------------------|
+| Tool:      filesystem.write                               |
+| Path:      /etc/app/config.json                           |
+| Size:      142 bytes                                      |
+| Session:   user=alice (SSO)  agent=assistant-prod         |
+| Requested: 2026-04-14 09:41:22 UTC                        |
+|                                                           |
+| Preview:                                                  |
+|   { "debug": true, "overrideSecurity": true }             |
+|                                                           |
+|      [ Approve ]   [ Deny ]   (auto-deny in 25s)          |
++-----------------------------------------------------------+
+```
+
+Design rules that make this resistant to SAFE-T1309:
+- The dialog text is rendered by the host from structured fields, not from free-form model output.
+- The "Approve" control triggers a host-side function; the model cannot synthesise a click.
+- The preview shows the distinguishing arguments, forcing the user's attention onto *what is being changed*, not onto a generic "tool call" prompt (reduces approval fatigue).
+- Timeout defaults to deny, not allow.
+
+### Example 3: Policy-engine configuration
+```yaml
+# Host-side configuration binding privileged tools to approval modes.
+privileged_tool_authorization:
+  mode: "enforce"   # log-only | enforce
+  default_timeout_seconds: 30
+  default_on_timeout: "deny"
+
+  tools:
+    filesystem.write:
+      approval: "human_confirm"
+      bind_fields: ["path", "content_sha256"]
+      scope_constraints:
+        - "path must be within session.workspace OR approver.role == 'admin'"
+
+    shell.exec:
+      approval: "policy_then_human"   # policy engine first; human on non-allowlisted commands
+      bind_fields: ["command", "args", "cwd"]
+
+    admin.rotate_credential:
+      approval: "multi_party"
+      approvers_required: 2
+      approver_roles: ["sre", "security"]
+      bind_fields: ["credential_id"]
+      ttl_seconds: 600
+```
+
+## Testing and Validation
+1. **Security Testing**:
+   - Attempt each SAFE-T1309 coercion pattern (authority spoofing, debug/simulation pretexting, pre-authorization assertion, role/mode override) against the host and verify that *no* privileged tool executes without a valid out-of-band artifact.
+   - Replay a previously issued capability token after expiry and verify denial.
+   - Submit a token whose `args_digest` does not match the call and verify denial.
+   - Attempt to induce the model to render a UI that mimics the approval dialog and confirm the real dialog is visually/structurally distinguishable (host-chromed).
+   - Verify fail-closed behaviour when the policy engine is unreachable.
+
+2. **Functional Testing**:
+   - Measure end-to-end latency added by the gate for each approval mode.
+   - Measure approval-fatigue proxy metrics (approvals per session, time-to-decide, approval/deny ratio).
+   - Verify that non-privileged tools are not affected.
+
+3. **Integration Testing**:
+   - Exercise the capability-token issuance, verification, and revocation lifecycle.
+   - Confirm audit events are emitted for grant, deny, timeout, and revocation, and that they can be correlated by session id.
+   - Run in log-only mode across a representative workload to tune the privileged list before enforcement.
+
+## Deployment Considerations
+
+### Resource Requirements
+- **CPU**: Low. Signature verification and policy evaluation are cheap relative to LLM inference.
+- **Memory**: Low. A small cache of active capability tokens per session.
+- **Storage**: Moderate. Audit logs for every privileged invocation and its decision; size scales with tool-call volume. Plan retention per compliance requirements.
+- **Network**: One extra synchronous hop per privileged call to the approval service or UI. For human flows, an out-of-band push channel (web socket, mobile push, Slack webhook).
+
+### Performance Impact
+- **Latency**: Milliseconds for capability-token or policy-engine flows; seconds-to-minutes for human-confirmation flows. Design the privileged-tool list so that the common path is the fast one.
+- **Throughput**: Unaffected for non-privileged tools. Privileged throughput is bounded by the approval channel's capacity.
+- **Resource Usage**: Negligible in the host process; human-attention cost is the dominant real-world resource.
+
+### Monitoring and Alerting
+- Approval request rate per session and per user (detect brute-forcing of the approval channel).
+- Denial rate and reasons (expired, mismatched args, policy-denied, timeout).
+- Time-to-decide distribution for human flows; alert on degradation.
+- Alert on approval requests for tools this session has never invoked before (possible ongoing SAFE-T1309 attempt).
+- Alert on capability tokens that verify but reference arguments lexically identical to the preceding user turn (possible dictated-call signal; combine with SAFE-T1309 detection guidance and SAFE-M-70 baselines).
+
+## Current Status (2026)
+The MCP specification places the consent and tool-safety burden on the host application and does not prescribe a specific mechanism ([Model Context Protocol Specification — Security and Trust & Safety](https://modelcontextprotocol.io/specification)). Implementations vary widely: some desktop hosts prompt for every tool call, others approve tools per-session at attach time, and headless/agentic deployments frequently skip per-invocation approval altogether in favour of pre-granted scopes. Public analyses of MCP deployments have repeatedly identified invocation-time authorization as an unevenly implemented control ([The Security Risks of Model Context Protocol (MCP) — Pillar Security, 2025](https://www.pillar.security/blog/the-security-risks-of-model-context-protocol-mcp)). Capability-based approaches with signed, short-lived grants are well-established in the broader security literature (see the capability-security references below) but are not yet standard practice in MCP host implementations.
+
+
+## References
+- [Model Context Protocol Specification — Security and Trust & Safety](https://modelcontextprotocol.io/specification) — primary source for the host-side consent and tool-safety principles this mitigation operationalises.
+- [OWASP Top 10 for Large Language Model Applications — LLM06: Excessive Agency](https://owasp.org/www-project-top-10-for-large-language-model-applications/) — framework context for over-autonomous tool invocation and the approval-fatigue failure mode.
+- [OWASP A01:2021 — Broken Access Control](https://owasp.org/Top10/A01_2021-Broken_Access_Control/) — general access-control framing for the authorization boundary at the tool-invocation layer.
+- [NIST SP 800-53 Rev. 5 — Access Control (AC) family](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final) — control families (AC-3 Access Enforcement, AC-6 Least Privilege, AC-17 Remote Access) that this mitigation maps to.
+- [Capability-Based Computer Systems — Henry M. Levy, 1984](https://homes.cs.washington.edu/~levy/capabook/) — canonical reference on capability-based security, the model underlying scoped, unforgeable grants.
+- [Capability Myths Demolished — Miller, Yee, Shapiro, 2003](https://srl.cs.jhu.edu/pubs/SRL2003-02.pdf) — foundational paper clarifying capability-security properties, relevant to the capability-token design in Example 1.
+- [RFC 8392 — CBOR Web Token (CWT)](https://datatracker.ietf.org/doc/html/rfc8392) and [RFC 7519 — JSON Web Token (JWT)](https://datatracker.ietf.org/doc/html/rfc7519) — standard carrier formats for short-lived, signed authorization artifacts.
+- [The Security Risks of Model Context Protocol (MCP) — Pillar Security, 2025](https://www.pillar.security/blog/the-security-risks-of-model-context-protocol-mcp) — community analysis highlighting invocation-time authorization gaps in MCP deployments.
+
+## Related Mitigations
+- [SAFE-M-29](../SAFE-M-29/README.md): Explicit Privilege Boundaries — complementary. SAFE-M-29 defines privilege levels, the boundaries between them, and the escalation rules that govern crossing those boundaries. SAFE-M-69 supplies the concrete per-invocation authorization artifact (capability token, human-approval signal, policy-engine grant) that M-29's escalation step consumes. Deployments use both: M-29 for the hierarchy and escalation policy, M-69 for the call-time artifact that proves the escalation was granted.
+- [SAFE-M-14](../SAFE-M-14/README.md): Server Allowlisting — narrows the surface of tools that can ever reach the authorization gate, reducing approval-fatigue load on SAFE-M-69.
+- [SAFE-M-16](../SAFE-M-16/README.md): Token Scope Limiting — bounds the blast radius of a successfully authorized privileged invocation by ensuring the underlying credentials are minimally scoped.
+- [SAFE-M-1](../SAFE-M-1/README.md): Architectural Defense — Control/Data Flow Separation — complementary upstream control that prevents tool outputs and retrieved content from acting as instructions, reducing the rate at which the authorization gate is asked to adjudicate injection-driven calls.
+- [SAFE-M-12](../SAFE-M-12/README.md): Audit Logging — consumes the grant/deny events emitted by SAFE-M-69 for detection and post-incident reconstruction.
+
+## Version History
+| Version | Date       | Changes               | Author       |
+|---------|------------|-----------------------|--------------|
+| 1.0     | 2026-04-14 | Initial documentation | bishnu bista |

--- a/mitigations/SAFE-M-70/README.md
+++ b/mitigations/SAFE-M-70/README.md
@@ -1,0 +1,228 @@
+# SAFE-M-70: Detective Control - Tool-Invocation Anomaly Detection & Baselining
+
+## Overview
+**Mitigation ID**: SAFE-M-70  
+**Category**: Detective Control  
+**Effectiveness**: Medium-High (depends on baseline quality and window tuning)  
+**Implementation Complexity**: Medium  
+**First Published**: 2026-04-14
+
+## Description
+Tool-Invocation Anomaly Detection & Baselining is a detective control that profiles **per-agent, per-user, per-tool** baselines of MCP tool-call behavior and raises alerts when live invocations deviate from those baselines along one or more feature dimensions. The goal is to catch tool-call events whose *shape* does not match what a given principal normally does — even when the individual call is syntactically valid and would pass static policy checks.
+
+Unlike coarse rate-limits or static allowlists, this mitigation models behavior at the tool-invocation layer: which tool was called, by which user/agent/session, with what argument cardinality, returning what result volume, at what time of day, to what destination. Anomalous deviations — a first-ever call to a privileged filesystem tool by a reporting agent, or a `sql_query` returning substantially more rows than this user's historical distribution — are scored and surfaced to a SIEM, approval gate, or human reviewer.
+
+**Distinction from SAFE-M-11 (Behavioral Monitoring).** SAFE-M-11 covers LLM behavioral analytics across the entire agent session, including model-generated text, reasoning patterns, tool-usage *sequences*, and conversation-level deviations. SAFE-M-70 is narrower: it operates on the single-event tool-invocation log stream, with per-entity statistical baselines over the numeric and categorical features of individual calls (volume, cardinality, destination, time). Deployments typically run both — M-11 for cross-turn behavioral signals, M-70 for per-call tool-stream baselines — with M-70 providing the high-precision per-invocation alerts that feed M-11's broader session-level correlation.
+
+It complements — not replaces — preventive controls such as explicit privilege boundaries (SAFE-M-29) and binding authorization; its role is to detect coercion and abuse that slip past prevention, especially for techniques such as SAFE-T1309 (privileged tool invocation via prompt manipulation) and SAFE-T1803 (database dump via MCP tools) where individual calls can look structurally legitimate.
+
+## Mitigates
+- [SAFE-T1309](../../techniques/SAFE-T1309/README.md): Privileged Tool Invocation via Prompt Manipulation
+- [SAFE-T1803](../../techniques/SAFE-T1803/README.md): Database Dump
+- [SAFE-T1104](../../techniques/SAFE-T1104/README.md): Over-Privileged Tool Abuse
+
+## Technical Implementation
+
+### Core Principles
+1. **Per-entity baselining, not global**: Baselines are keyed by `(tenant, user, agent, tool)` — or a coarser subset when data is sparse — so that a new-hire analyst is not compared to a nightly batch service account.
+2. **Multi-dimensional features**: No single feature (e.g., call rate) is sufficient. Track volume, argument cardinality, result size, destination, and temporal features together so that an adversary cannot evade by flattening one axis.
+3. **Degrade open until tuned**: During initial rollout, anomaly signals are alert-only (SIEM/notification). Only promote high-confidence rules to blocking or approval-gating after false-positive rates are characterized.
+4. **First-time-use is a first-class signal**: First-ever use of a privileged tool by a given principal, or first-ever destination for an export, is often more valuable than statistical deviation.
+5. **Bounded baseline windows**: Use rolling windows (e.g., 30–90 days) with decay, so legitimate drift is learned but stale behavior does not mask compromise.
+
+### Architecture Components
+```text
+ ┌───────────────────────┐      ┌──────────────────────┐      ┌─────────────────────┐
+ │ MCP Host / Server     │      │ Feature Extraction   │      │ Baseline Store      │
+ │ tool-invocation log ──┼─────▶│ (per-call features)  │─────▶│ (per-entity stats,  │
+ │ (SAFE-M-12 substrate) │      │                      │      │  rolling windows)   │
+ └───────────────────────┘      └──────────┬───────────┘      └──────────┬──────────┘
+                                           │                              │
+                                           ▼                              ▼
+                                  ┌──────────────────────────────────────────────┐
+                                  │ Anomaly Scorer                               │
+                                  │  - z-score / robust z on numeric features    │
+                                  │  - isolation forest on joint feature vector  │
+                                  │  - first-time-use / rare-category rules      │
+                                  └──────────────────┬───────────────────────────┘
+                                                     │ scored events
+                                                     ▼
+                                  ┌──────────────────────────────────────────────┐
+                                  │ Alert Pipeline                               │
+                                  │  - SIEM (Splunk / Sentinel / Elastic)        │
+                                  │  - Approval gate (human-in-the-loop)         │
+                                  │  - Case management / on-call paging          │
+                                  └──────────────────────────────────────────────┘
+```
+
+### Prerequisites
+- Structured MCP tool-invocation logging in place — see [SAFE-M-12: Audit Logging](../SAFE-M-12/README.md) — emitting at minimum: timestamp, tenant, user id, agent id, session id, tool name, a serialized form of the arguments (or a structured argument tree) sufficient to compute byte-size and field-cardinality features, result row-count and byte-size, destination (if applicable), and outcome.
+- A stable identity schema for users, service accounts, and agents so baselines can be keyed consistently.
+- Access to at least **30 days** of historical tool-invocation data before enabling production alerting; 60–90 days is preferred for workloads with weekly/monthly seasonality.
+- A SIEM or equivalent alert sink capable of ingesting scored events and supporting analyst triage.
+- (Optional but recommended) a tool inventory classifying each tool as `privileged` or `non-privileged` to prioritize rules.
+
+### Implementation Steps
+1. **Design Phase**:
+   - Enumerate the tool surface and tag each tool with sensitivity (privileged vs. non-privileged) and data class (bulk-read, mutation, egress, etc.).
+   - Define the entity key hierarchy (tenant > user > agent > tool) and the fallback policy when a finer key has insufficient data.
+   - Select the initial feature set (see extraction example below) and document thresholds.
+
+2. **Development Phase**:
+   - Implement feature extraction over the tool-invocation log substrate.
+   - Build the baseline store using rolling aggregates (e.g., per-entity mean/stddev, per-entity HyperLogLog for cardinality, per-entity destination sets).
+   - Implement scorers: robust z-score for numeric features, first-time-use rule for categorical features, isolation forest (or similar) over the joint feature vector for tail anomalies.
+   - Instrument alert enrichment with the raw tool call, entity baselines, and a human-readable reason string.
+
+3. **Deployment Phase**:
+   - Run in shadow mode for at least 2 baseline windows; review false-positive rate and tune.
+   - Enable SIEM alerting for high-severity rules (privileged-tool first-use, large-magnitude robust-z result-size anomalies).
+   - Later, gate a narrow subset of highest-severity anomalies behind a human approval step at the MCP host.
+   - Review and retune at least quarterly, or after any material change to the agent/tool fleet.
+
+## Benefits
+- **Catches semantically valid but behaviorally abnormal calls**: Detects abuse patterns where a call is structurally legitimate but wrong for this principal (coerced privileged invocation, bulk-export abuse).
+- **Complements preventive controls**: Fills the gap when prevention (SAFE-M-29, authorization gates) is bypassed or misconfigured.
+- **Leverages existing log substrate**: Builds on the MCP tool-invocation logs required by SAFE-M-12; marginal cost is modeling and alerting, not new instrumentation.
+- **Supports forensics**: The baseline store itself is a useful investigative artifact during incident response.
+
+## Limitations
+- **Cold start**: New users, new agents, and newly deployed tools have no baseline; these are either over-alerted (first-time-use firing constantly) or under-alerted (statistical rules silent until enough data accumulates).
+- **Legitimate bursty workloads**: Scheduled jobs, migrations, quarter-end reporting, and large backfills legitimately spike volume/cardinality and will generate false positives unless modeled as separate entities or given explicit exemptions.
+- **Slow-roll evasion**: A patient adversary can stay under per-call thresholds (e.g., exfiltrating in many small queries over days). Mitigation requires session- and principal-level aggregation with long windows, which increases detection latency.
+- **Per-entity data sparsity**: Very fine-grained keys (per-user, per-tool) often have too few samples for stable statistics; coarsening the key trades specificity for stability.
+- **Not a prevention control**: This mitigation detects after invocation. It must be paired with preventive controls for high-impact tools.
+
+## Implementation Examples
+
+### Example 1: Feature extraction (pseudocode)
+```python
+# Pseudocode — not a complete implementation.
+# Input: a single tool-invocation event from the SAFE-M-12 audit log.
+def extract_features(event):
+    return {
+        "entity_key":      (event.tenant, event.user_id, event.agent_id, event.tool_name),
+        "session_id":      event.session_id,
+        "tool_name":       event.tool_name,
+        "is_privileged":   TOOL_INVENTORY[event.tool_name].privileged,
+        "arg_byte_size":   len(event.arguments_serialized),
+        "arg_cardinality": count_distinct_fields(event.arguments),
+        "result_rows":     event.result.get("row_count", 0),
+        "result_bytes":    event.result.get("bytes", 0),
+        "destination":     event.result.get("destination"),       # e.g. s3://... or None
+        "hour_of_day":     event.timestamp.hour,
+        "day_of_week":     event.timestamp.weekday(),
+    }
+```
+
+### Example 2: Scoring rules
+```python
+# Robust z-score on a numeric feature vs per-entity baseline.
+def robust_z(value, baseline):
+    # baseline: {"median": float, "mad": float, "n": int}
+    if baseline["n"] < 30 or baseline["mad"] == 0:
+        return None  # insufficient data; fall back to first-time-use rule
+    return 0.6745 * (value - baseline["median"]) / baseline["mad"]
+
+def score_event(features, baselines):
+    alerts = []
+
+    # Rule A: result_rows far above this entity's historical median -> possible SAFE-T1803 bulk export.
+    # A robust z-score over the log-transformed row count is a unitless deviation measure; the
+    # threshold 3.5 is a commonly cited extreme-outlier cut for MAD-based scores (not a fixed
+    # row-count multiple). Calibrate per deployment.
+    rz = robust_z(features["result_rows"], baselines["result_rows"])
+    if rz is not None and rz > 3.5:
+        alerts.append(("result_rows.extreme", rz))
+
+    # Rule B: first-ever use of a privileged tool by this principal -> possible SAFE-T1309
+    if features["is_privileged"] and features["entity_key"] not in baselines["seen_entities"]:
+        alerts.append(("privileged_tool.first_use", 1.0))
+
+    # Rule C: new destination for an export tool
+    dest = features["destination"]
+    if dest and dest not in baselines["destinations"]:
+        alerts.append(("destination.first_seen", 1.0))
+
+    return alerts
+```
+
+### Example 3: SIEM query sketch (Splunk-style)
+First-time-use is an **all-time** signal, not a within-window one. The pattern below joins
+the live window against a persisted lookup of every `(user, agent, tool)` triple ever observed;
+the lookup is refreshed by a separate daily job that appends newly seen entities. The live
+query fires only when the current triple is absent from that persisted history.
+
+```text
+index=mcp_tool_invocations sourcetype=mcp:tool_call earliest=-1h
+| join type=left tool_name [| inputlookup tool_inventory.csv where privileged=true]
+| where privileged=true
+| lookup seen_entities.csv user_id agent_id tool_name OUTPUT first_seen
+| where isnull(first_seen)
+| eval alert="privileged_tool.first_use"
+```
+
+A separate scheduled job maintains `seen_entities.csv`:
+```text
+index=mcp_tool_invocations earliest=-90d
+| stats min(_time) as first_seen by user_id, agent_id, tool_name
+| outputlookup seen_entities.csv
+```
+
+## Testing and Validation
+1. **Security Testing**:
+   - Replay synthetic SAFE-T1309 traces (privileged tool invoked after a coercion prompt) and verify `privileged_tool.first_use` or argument-cardinality rules fire.
+   - Replay synthetic SAFE-T1803 traces (wide-table `SELECT` returning 10^6+ rows) and verify result-size robust-z rules fire.
+   - Verify rules do not fire for a matched-entity legitimate replay.
+
+2. **Functional Testing**:
+   - Validate baseline store updates are idempotent and survive replay.
+   - Measure end-to-end scoring latency for a realistic event rate (target: sub-second for SIEM path, a few seconds is acceptable).
+
+3. **Integration Testing**:
+   - Confirm alerts land in SIEM with the expected schema and severity.
+   - Confirm approval-gated tools actually pause execution pending human response when the high-severity path is enabled.
+
+## Deployment Considerations
+
+### Resource Requirements
+- **CPU**: Modest; per-event feature extraction and scoring is O(1) per event against a cached baseline.
+- **Memory**: Dominated by the baseline store (per-entity sketches). Plan roughly 1–10 KB per `(user, tool)` pair; size accordingly.
+- **Storage**: Historical baselines and rolling windows — commonly 10s of GB for mid-size deployments; reuse existing log storage where possible.
+- **Network**: Negligible beyond SIEM ingestion.
+
+### Performance Impact
+- **Latency**: Out-of-band scoring adds none to tool execution. An inline approval gate adds whatever human-response latency the policy requires.
+- **Throughput**: Designed to run asynchronously; should not throttle MCP traffic.
+- **Resource Usage**: Modest and predictable; dominated by the SIEM pipeline, not the MCP host.
+
+### Monitoring and Alerting
+- Alerts-per-hour per rule (watch for alert storms from poorly tuned thresholds).
+- Baseline freshness per entity (stale baselines indicate ingestion problems).
+- Coverage: fraction of tool calls with a matched baseline entity key.
+- Mean time between a privileged-tool-first-use alert and analyst acknowledgement.
+
+## Current Status (2026)
+UEBA-style analytics for LLM agents and MCP tool usage remain **nascent** as of 2026. Practitioner writeups indicate that most production deployments still rely on **hard thresholds** (per-tool rate limits, fixed row-count caps, destination allowlists) rather than learned per-entity baselines [1][2]. Research on anomaly detection for LLM-driven systems exists [3], but production-grade MCP-specific UEBA is still catching up with the rapid growth of the agent ecosystem. Defenders adopting this mitigation today should expect to invest in baseline tuning, accept a cold-start period, and pair it with preventive controls rather than treating it as a standalone defense.
+
+## References
+- [1] [Model Context Protocol Specification](https://modelcontextprotocol.io/specification)
+- [2] [OWASP Top 10 for Large Language Model Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [3] [Large Language Models for Forecasting and Anomaly Detection: A Systematic Literature Review (2024)](https://arxiv.org/abs/2402.10350)
+- [4] [NIST SP 800-92: Guide to Computer Security Log Management](https://csrc.nist.gov/publications/detail/sp/800-92/final)
+- [5] [NISTIR 8219: Securing Manufacturing Industrial Control Systems — Behavioral Anomaly Detection](https://csrc.nist.gov/publications/detail/nistir/8219/final)
+- [6] [Anomaly Detection: A Survey — Chandola, Banerjee, Kumar, ACM Computing Surveys 2009](https://dl.acm.org/doi/10.1145/1541880.1541882)
+- [7] [Isolation Forest — Liu, Ting, Zhou, ICDM 2008](https://ieeexplore.ieee.org/document/4781136)
+- [8] [MITRE ATT&CK T1213 — Data from Information Repositories](https://attack.mitre.org/techniques/T1213/)
+
+## Related Mitigations
+- [SAFE-M-11](../SAFE-M-11/README.md): Behavioral Monitoring — broader LLM behavioral analytics over model outputs and sequences; SAFE-M-70 is a specialization focused on the tool-invocation event stream.
+- [SAFE-M-12](../SAFE-M-12/README.md): Audit Logging — provides the structured log substrate on which SAFE-M-70 operates; a hard prerequisite.
+- [SAFE-M-20](../SAFE-M-20/README.md): Anomaly Detection (OAuth request patterns) — complementary control at the OAuth/auth layer; SAFE-M-70 covers the in-session tool-call layer.
+- [SAFE-M-29](../SAFE-M-29/README.md): Explicit Privilege Boundaries — preventive counterpart for SAFE-T1309; SAFE-M-70 detects what slips past it.
+- [SAFE-M-36](../SAFE-M-36/README.md): Model Behavior Monitoring — complementary, focused on model inputs/outputs rather than the tool-invocation event stream.
+
+## Version History
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-04-14 | Initial documentation | bishnu bista |

--- a/mitigations/SAFE-M-71/README.md
+++ b/mitigations/SAFE-M-71/README.md
@@ -1,0 +1,264 @@
+# SAFE-M-71: Query Guardrails & Result Limits
+
+## Overview
+**Mitigation ID**: SAFE-M-71  
+**Category**: Preventive Control  
+**Effectiveness**: High (when enforced at the connector/tool layer, not in the model's context)  
+**Implementation Complexity**: Medium  
+**First Published**: 2026-04-14
+
+## Description
+Query Guardrails & Result Limits is a preventive control for MCP tools that execute queries against databases, data warehouses, or other structured stores. A policy engine sits between the model-proposed tool call and the backing datastore, parses the proposed query, inspects its **shape** (not just its text), and either dispatches, rewrites, rejects, or escalates the call. Pre-dispatch guardrails may also inject a hard `LIMIT` into an otherwise-approved query before sending it to the datastore, so the query cannot request an unbounded scan in the first place. Post-execution size capping on the return path is a separate, complementary control (see SAFE-M-23). Because enforcement lives outside the model, the agent cannot talk its way past the gate.
+
+Unlike post-hoc truncation, this control can refuse a query **before** it runs, preventing load on the target database, avoiding memory pressure on the MCP host, and keeping sensitive data from ever being read off disk. Typical rules include: reject `SELECT *` on privileged tables, reject unbounded scans (no `WHERE` clause, no time filter) on large tables, require parameterized or pre-vetted stored procedures for bulk access, cap result rows per tool and per session, and route explicit "bulk export" requests through an exception workflow with human approval and audit logging. Guardrails are the primary defense against SAFE-T1803 (Database Dump) driven via MCP query tools.
+
+## Mitigates
+- [SAFE-T1803](../../techniques/SAFE-T1803/README.md): Database Dump (primary)
+- [SAFE-T1104](../../techniques/SAFE-T1104/README.md): Over-Privileged Tool Abuse (where the over-privilege is expressed as unbounded query capability)
+
+## Technical Implementation
+
+### Core Principles
+1. **Enforcement outside the model**: The policy engine is a separate process or library invoked by the MCP tool handler. The model cannot inspect, disable, or bypass it through prompt content.
+2. **Shape-level rules, not string matching**: Parse the proposed query into an AST (sqlparse, sqlglot, or a DB-native `EXPLAIN`/plan inspection) and reason about tables, projected columns, predicates, joins, and estimated scan size. String-matching on `SELECT *` is trivially evaded by whitespace, comments, or column enumeration.
+3. **Fail closed**: If the parser errors, the policy engine is unreachable, or estimated scan size cannot be determined, the call is denied. Availability of the gate is a safety property.
+4. **Structured exceptions with audit**: Legitimate bulk needs (backups, migrations, analytics exports) route through a named exception with an approver, a TTL, and an immutable audit record — never through a generic "disable guardrails" flag.
+5. **Compose with post-execution controls**: Guardrails are the first line; SAFE-M-23 (truncation), SAFE-M-16 (scope-limited credentials), and DLP on outputs remain in place.
+
+### Architecture Components
+```text
+                                +---------------------------------+
+  Model / Agent -- proposes --> |  MCP Tool Handler (db_query)    |
+                                |                                 |
+                                |   +-------------------------+   |
+                                |   | Policy Engine Gate      |   |
+                                |   |  1. SQL parser (AST)    |   |
+                                |   |  2. Shape rules:        |   |
+                                |   |     - privileged tables |   |
+                                |   |     - SELECT * deny     |   |
+                                |   |     - WHERE required    |   |
+                                |   |     - join depth        |   |
+                                |   |  3. Quota check         |   |
+                                |   |     (row/byte caps)     |   |
+                                |   |  4. Exception lookup    |   |
+                                |   +-----------+-------------+   |
+                                |               |                 |
+                                |    deny       | allow (maybe    |
+                                |    reject     | with LIMIT      |
+                                |    / escalate | injected)       |
+                                |               v                 |
+                                |     +---------------------+     |
+                                |     | DB Driver / Conn    |-----+--> Database / Warehouse
+                                |     +----------+----------+     |
+                                |                |                |
+                                |     +----------v----------+     |
+                                |     | Result Cap (rows,   |     |
+                                |     | bytes, timeout)     |     |
+                                |     +----------+----------+     |
+                                +----------------|----------------+
+                                                 v
+                                          Audit Log / SIEM
+                                                 |
+                                                 v
+                                        Agent / Tool Response
+```
+
+### Prerequisites
+- A SQL parser for each target dialect (e.g., [sqlparse](https://github.com/andialbrecht/sqlparse), [sqlglot](https://github.com/tobymao/sqlglot)) or access to a DB-native query planner (`EXPLAIN`, `EXPLAIN ANALYZE`, `SHOW PLAN`).
+- A policy-expression language or structured config. Off-the-shelf options include [Open Policy Agent (OPA)](https://www.openpolicyagent.org/), [Cerbos](https://cerbos.dev/), or [Permit.io](https://www.permit.io/).
+- An MCP connector/tool layer that can inject a pre-dispatch hook — the handler must not talk to the DB directly.
+- A list of privileged tables / columns, plus per-tool row and byte caps agreed with data owners.
+- An audit sink (SIEM or write-once log) that receives every allow, deny, and exception decision.
+
+### Implementation Steps
+1. **Design Phase**:
+   - Classify datastores and tables: `privileged` (PII, credentials, payments, auth logs), `internal`, `public`. Record in a version-controlled registry.
+   - Define per-tool, per-role row and byte caps (e.g., `analyst_query`: 10k rows / 25 MB; `support_query`: 500 rows / 2 MB).
+   - Define shape-level deny rules: no `SELECT *` on privileged tables; every query against large tables must include a bounded predicate on an indexed column; joins that cross privilege classes require approval.
+   - Design the exception workflow: who approves, TTL, which tables are eligible, what log format.
+
+2. **Development Phase**:
+   - Integrate a SQL parser in the MCP tool handler. Walk the AST to extract referenced tables, projected columns, presence of `WHERE`, join count, and any `LIMIT`.
+   - Implement deny rules as policy (OPA Rego, Cerbos policies, or typed Python rules). Load from a signed, versioned config.
+   - On allow, inject a hard `LIMIT` if absent and attach a statement-level timeout.
+   - On approved queries, inject a hard `LIMIT` before dispatch when none is present in the submitted SQL; attach a statement-level timeout. Post-execution byte caps on the returned payload are out of scope here — they belong to SAFE-M-23.
+   - Wire audit logging: every decision is logged with query hash, tool name, caller identity, decision, matched rule, and the `LIMIT` injected (if any).
+
+3. **Deployment Phase**:
+   - Roll out in `log-only` mode first; baseline what production queries look like and tune rules to minimize false positives.
+   - Flip to `enforce` mode table-by-table, starting with the highest-sensitivity tables.
+   - Stand up the exception workflow and dashboards. Monitor deny rates, exception rates, and 95th-percentile guardrail latency.
+   - Red-team the gate with evasion attempts (comments, unicode, subqueries, CTEs, prepared statements).
+
+## Benefits
+- **Prevents the dump before it happens**: Unlike output truncation, no rows are read off disk and no DB resources are spent on a rejected query.
+- **Works even against a fully compromised agent**: Because enforcement is outside the model, prompt injection cannot turn guardrails off.
+- **Produces clean audit evidence**: Every denied or escalated query is a high-signal event for detection (SAFE-T1803 IoC feed).
+- **Composable**: Layers cleanly with SAFE-M-16 (DB-side least privilege), SAFE-M-23 (post-execution truncation), and DLP controls on outputs.
+
+## Limitations
+- **Does not prevent pattern circumvention via many small queries**: A loop of small, well-shaped queries can still exfiltrate a table row-by-row. Rate limiting and per-session cumulative caps are separate controls and must be paired.
+- **Parser bugs and dialect drift**: A malformed query, dialect-specific syntax, or exotic constructs (stored procs, dynamic SQL via `EXECUTE`) can slip past an AST-only check. Prefer combining AST inspection with a server-side `EXPLAIN` estimate when available.
+- **Per-row sensitivity still needs DLP**: A shape-compliant query can still return sensitive columns. Column-level masking, tokenization, or output DLP — see [SAFE-M-72](../SAFE-M-72/README.md) — is complementary and required for regulated data.
+- **Operational tuning cost**: False-positive denies frustrate analysts. Expect 2–6 weeks of log-only tuning before enforcement on busy warehouses.
+- **Stored-procedure and ORM blind spots**: Queries generated by ORMs or wrapped in stored procedures may obscure the effective shape; inspect the rendered SQL or the procedure body, not the caller signature.
+
+## Implementation Examples
+
+### Example 1: Python query-shape checker (pseudocode)
+```python
+import sqlglot
+from sqlglot import exp
+
+PRIVILEGED_TABLES = {"users", "auth_logs", "payments", "sessions", "api_tokens"}
+DEFAULT_ROW_CAP = 1_000
+BYTE_CAP = 2 * 1024 * 1024  # 2 MB
+
+class GuardrailDenied(Exception):
+    pass
+
+def check_query(sql: str, dialect: str, tool: str, caller: str, exceptions: set[str]) -> str:
+    try:
+        tree = sqlglot.parse_one(sql, read=dialect)
+    except sqlglot.errors.ParseError as e:
+        # Fail closed on parse errors.
+        raise GuardrailDenied(f"unparseable SQL: {e}")
+
+    if not isinstance(tree, exp.Select):
+        raise GuardrailDenied("only SELECT permitted for this tool")
+
+    tables = {t.name for t in tree.find_all(exp.Table)}
+    star = any(isinstance(p, exp.Star) for p in tree.find_all(exp.Star))
+
+    if star and tables & PRIVILEGED_TABLES:
+        raise GuardrailDenied(
+            f"SELECT * on privileged tables denied: {tables & PRIVILEGED_TABLES}"
+        )
+
+    if not tree.find(exp.Where) and tables & PRIVILEGED_TABLES:
+        if f"{tool}:unbounded" not in exceptions:
+            raise GuardrailDenied("unbounded scan on privileged table denied")
+
+    # Inject row cap if absent.
+    if not tree.args.get("limit"):
+        tree.set("limit", exp.Limit(expression=exp.Literal.number(DEFAULT_ROW_CAP)))
+
+    return tree.sql(dialect=dialect)
+```
+
+### Example 2: OPA-style Rego policy fragment
+```rego
+package mcp.db_query
+
+default allow := false
+
+# Deny SELECT * on privileged tables.
+deny[msg] {
+    input.query.has_star
+    some t
+    input.query.tables[t]
+    privileged_tables[t]
+    msg := sprintf("SELECT * on privileged table %q denied", [t])
+}
+
+# Deny unbounded scans on large tables unless a scoped exception is active.
+deny[msg] {
+    input.query.missing_where
+    some t
+    input.query.tables[t]
+    large_tables[t]
+    not input.exceptions["bulk_export"]
+    msg := sprintf("unbounded scan on large table %q denied", [t])
+}
+
+allow {
+    count(deny) == 0
+    input.query.row_estimate <= input.policy.row_cap
+}
+
+privileged_tables := {"users", "auth_logs", "payments", "sessions"}
+large_tables      := {"users", "events", "sessions", "access_logs"}
+```
+
+### Example 3: Per-tool config
+```yaml
+guardrails:
+  enforcement_mode: enforce        # log_only | enforce
+  fail_closed: true
+  tools:
+    analyst_query:
+      row_cap: 10000
+      byte_cap_mb: 25
+      statement_timeout_ms: 15000
+      deny_select_star_on: [users, auth_logs, payments]
+      require_where_on:    [users, events, access_logs]
+    support_query:
+      row_cap: 500
+      byte_cap_mb: 2
+      statement_timeout_ms: 5000
+      deny_select_star_on: [users, auth_logs, payments, api_tokens]
+  exceptions:
+    bulk_export:
+      approver_role: data_protection_officer
+      ttl_minutes: 60
+      audit_required: true
+```
+
+## Testing and Validation
+1. **Security Testing**:
+   - Attempt `SELECT *` on privileged tables via direct text, whitespace variants, comments, unicode look-alikes, subqueries, and CTEs. All must deny.
+   - Attempt unbounded scans without `WHERE`, with trivially-true predicates (`WHERE 1=1`), and with predicates on unindexed columns. Unbounded and trivially-true variants must deny.
+   - Confirm fail-closed behavior when the policy engine process is killed.
+   - Attempt small-query exfiltration loops; confirm cumulative session caps fire (if implemented).
+2. **Functional Testing**:
+   - Validate that representative analyst, support, and reporting queries still run.
+   - Measure added latency at p50/p95/p99 with the parser + policy engine in the path.
+3. **Integration Testing**:
+   - Confirm audit records land in SIEM with query hash, decision, matched rule, caller, and tool.
+   - Exercise the exception workflow end-to-end, including TTL expiry.
+
+## Deployment Considerations
+
+### Resource Requirements
+- **CPU**: Parsing and policy evaluation are typically sub-millisecond per query; budget ~1–5% overhead on the MCP host.
+- **Memory**: Policy bundles and AST buffers are small; ~tens of MB per worker.
+- **Storage**: Audit logs dominate; plan for SIEM ingest proportional to tool call volume.
+- **Network**: Negligible unless using a remote OPA / Cerbos server; keep the policy engine local or sidecar for latency.
+
+### Performance Impact
+- **Latency**: Expect +1–10 ms per tool call for AST + policy evaluation. DB-native `EXPLAIN` estimates add a round trip.
+- **Throughput**: Stateless checks scale horizontally with the tool handler.
+- **Resource Usage**: Net positive at the DB layer — denied queries never consume DB CPU, I/O, or buffer pool.
+
+### Monitoring and Alerting
+- Guardrail deny rate per tool and per caller (spikes indicate evasion or misconfiguration).
+- Exception activation rate and approver identity.
+- p95 guardrail latency; alert if parser budget exceeded.
+- Fail-closed events (policy engine unreachable).
+- Rate at which approved queries required a guardrail-injected `LIMIT`.
+
+## Current Status (2026)
+Production MCP deployments with database connectors typically ship with either naive string-matching guardrails ("reject if the string `SELECT *` appears") or none at all. Policy engines such as OPA, Cerbos, and Permit.io are mature for RBAC/ABAC but integration into MCP tool handlers remains custom work, and public reference implementations for SQL-shape rules are sparse. Cloud providers recommend query guardrails and schema-aware DLP as core defenses against bulk database theft from agent-driven workloads ([NSA/CISA Cloud Top 10, 2024](https://media.defense.gov/2024/Mar/07/2003407862/-1/-1/0/CSI-CLOUDTOP10-SECURE-DATA.PDF); [Google Cloud — 4 Steps to Stop Data Exfiltration](https://cloud.google.com/blog/products/identity-security/4-steps-to-stop-data-exfiltration-with-google-cloud)).
+
+## References
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/specification)
+- [OWASP Top 10 for Large Language Model Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [MITRE ATT&CK T1213.006 — Databases](https://attack.mitre.org/techniques/T1213/006/)
+- [MITRE ATT&CK M1041 — Data Loss Prevention](https://attack.mitre.org/mitigations/M1041/)
+- [NSA & CISA — Top 10 Cloud Security Mitigation Strategies: Secure Data in the Cloud (CSI, March 2024)](https://media.defense.gov/2024/Mar/07/2003407862/-1/-1/0/CSI-CLOUDTOP10-SECURE-DATA.PDF)
+- [Google Cloud — 4 Steps to Stop Data Exfiltration with Google Cloud](https://cloud.google.com/blog/products/identity-security/4-steps-to-stop-data-exfiltration-with-google-cloud)
+- [Open Policy Agent (OPA)](https://www.openpolicyagent.org/)
+- [Cerbos Authorization](https://cerbos.dev/)
+- [sqlglot — SQL parser and transpiler](https://github.com/tobymao/sqlglot)
+- [sqlparse — non-validating SQL parser](https://github.com/andialbrecht/sqlparse)
+
+## Related Mitigations
+- [SAFE-M-23](../SAFE-M-23/README.md): Tool Output Truncation — complementary; applies hard caps **after** execution. SAFE-M-71 rejects dangerous queries before they run; together they provide defense in depth.
+- [SAFE-M-16](../SAFE-M-16/README.md): Token Scope Limiting — complementary; reduces the DB-side permission surface so that even a guardrail bypass returns less data.
+- [SAFE-M-29](../SAFE-M-29/README.md): Explicit Privilege Boundaries — defines the privilege structure that guardrails enforce at the query layer.
+- [SAFE-M-72](../SAFE-M-72/README.md): Data Loss Prevention on Tool Outputs — complementary; SAFE-M-71 blocks overbroad queries at ingress, SAFE-M-72 masks or redacts sensitive columns at egress when a query slips through.
+
+## Version History
+| Version | Date       | Changes                 | Author       |
+|---------|------------|-------------------------|--------------|
+| 1.0     | 2026-04-14 | Initial documentation   | bishnu bista |

--- a/mitigations/SAFE-M-72/README.md
+++ b/mitigations/SAFE-M-72/README.md
@@ -1,0 +1,260 @@
+# SAFE-M-72: Data Security - Data Loss Prevention on Tool Outputs
+
+## Overview
+**Mitigation ID**: SAFE-M-72
+**Category**: Data Security
+**Effectiveness**: Medium-High (inline masking and tokenization are deterministic; policy accuracy is bounded by classification quality and detector recall)
+**Implementation Complexity**: Medium-High
+**First Published**: 2026-04-14
+**Author**: bishnu bista
+
+## Description
+Data Loss Prevention (DLP) on Tool Outputs applies column-level classification, masking, tokenization, and sensitive-content detection to the results returned by MCP tools **before** those results enter the agent's context window or are surfaced to a user. The control treats every tool response as an untrusted egress point from a protected data store: structured rows from database connectors, semi-structured payloads from API wrappers, and free-text fields from document/knowledge tools are all inspected against a policy that maps sensitivity labels (PII, PCI, PHI, secrets, IP) to actions (allow, mask, tokenize, redact, block, alert).
+
+Unlike prompt-injection defenses that look for instruction-shaped content in model inputs, SAFE-M-72 operates on the **outbound** path of the tool boundary and is specifically tuned to prevent bulk disclosure of sensitive records even when the underlying query is syntactically valid and the agent is behaving as intended. The control composes schema-authoritative filtering (using a data classification catalog that maps columns → labels) with content-based scanners (regex, dedicated validators per identifier class — Luhn / MOD-10 for PAN, MOD-97 for IBAN, format/area checks for US SSN — Named Entity Recognition, ML classifiers, and embedding-based secret detectors) to cover both typed and untyped fields. Every masking or block decision is logged as an audit event, giving defenders a high-signal telemetry source for detecting exfiltration attempts that evade upstream guardrails [1][2][3].
+
+## Mitigates
+- [SAFE-T1803](../../techniques/SAFE-T1803/README.md): Database Dump — primary mitigation; even if query-layer guardrails are bypassed, PII/PCI/secret columns are masked or tokenized before the agent sees the rows, capping the blast radius of a bulk `SELECT`.
+- [SAFE-T1008](../../techniques/SAFE-T1008/README.md): Credential-in-File — secret scanners in the output path redact tokens, keys, and passwords that would otherwise be returned verbatim by file-read or config-dump tools.
+- [SAFE-T1102](../../techniques/SAFE-T1102/README.md): Prompt Injection (Multiple Vectors) — secondary mitigation; bounds the information an injection-hijacked agent can actually exfiltrate through tool results, because sensitive payloads never reach the model context in clear form.
+
+## Technical Implementation
+
+### Core Principles
+1. **Classify at the schema layer where possible**: a column-level classification catalog (column → sensitivity label) is authoritative, deterministic, and cheap to enforce. Every field with a label gets its policy action applied without content inspection.
+2. **Fall back to content scanning for unclassified or free-text fields**: JSON blobs, document bodies, log lines, and notes columns must be scanned with regex/validator combinations (Luhn / MOD-10 for PAN, MOD-97 for IBAN, format/area checks for US SSN, entropy + structural checks for API keys) and ML classifiers for unstructured PII [4][5].
+3. **Default deny for unknown sensitivity**: fields with no classification label and no content-scanner hit are replaced by a summary (length, type) rather than passed through raw, unless an allowlist explicitly marks the column or field as non-sensitive. Newly observed columns inherit this summarization default until a catalog entry is added.
+4. **Distinguish masking, redaction, and tokenization**: **masking** (e.g., `****1234` for a PAN) and **redaction** (full removal) are one-way — the clear value cannot be recovered from the output. **Tokenization** replaces the value with an opaque token whose clear form can be retrieved only through an authenticated detokenization channel; it is reversible by design and appropriate where a downstream system must correlate, join, or later re-hydrate the real value [6][7]. The policy **MUST** pick one per label and document the choice; mixing masking and tokenization for the same label breaks referential behavior.
+5. **Audit every trigger**: record policy hits (field path, label, action, caller identity, tool name) to an append-only log so bulk-dump attempts show up as spikes in mask/block counts even when the agent returned a "successful" response.
+
+### Architecture Components
+```
+                 ┌──────────────────────────────────────────────┐
+   MCP Tool ─────▶  Connector (DB driver / HTTP client / FS)    │
+   request        └──────────────────────────────────────────────┘
+                                     │ raw rows / JSON / text
+                                     ▼
+                 ┌──────────────────────────────────────────────┐
+                 │         DLP Pipeline (per response)          │
+                 │                                              │
+                 │  1. Schema-aware Column Classifier           │
+                 │     (lookup against data catalog)            │
+                 │  2. Sensitive-Pattern Scanner                │
+                 │     (regex + validators + NER + ML)          │
+                 │  3. Secret Detector (composes SAFE-M-63)     │
+                 │  4. Policy Engine                            │
+                 │     label + context -> action                │
+                 │  5. Transform (mask/tokenize/redact/block)   │
+                 │  6. Audit Emitter (SIEM)                     │
+                 └──────────────────────────────────────────────┘
+                                     │ sanitized payload
+                                     ▼
+                 ┌──────────────────────────────────────────────┐
+                 │  MCP Tool Handler ──▶ Agent Context / User   │
+                 └──────────────────────────────────────────────┘
+```
+
+### Prerequisites
+- A data classification catalog covering high-value datastores (column → sensitivity label). Discovery tools — AWS Macie, Google Cloud DLP discovery scans, Microsoft Purview — are used **to populate this catalog**, not as inline scanners in the request path [3][8][9].
+- A DLP engine capable of inline recognizer composition on each tool response. Common engine choices: Microsoft Presidio (open-source, recognizer-based NLP) [1], Google Cloud DLP / Sensitive Data Protection (API-based inline inspection) [3], Nightfall DLP (API-based inline inspection) [10]. A tokenization service is required when reversibility is needed for any label; common choices include Fortanix Data Security Manager [6] and cloud-native format-preserving encryption [7].
+- AWS Macie and Microsoft Purview are catalog/discovery inputs to this pipeline, not inline DLP engines — they do not sit in the per-request critical path.
+- A connector-layer hook point inside each MCP server (SQL driver wrapper, HTTP response middleware, filesystem read wrapper) where responses can be intercepted before serialization back to the tool caller.
+- Optional: a token vault or format-preserving encryption service if reversible tokenization is required [6][7].
+- Audit sink (SIEM, append-only log, or OpenTelemetry pipeline) for DLP events.
+
+### Implementation Steps
+
+1. **Design Phase**:
+   - Inventory the datastores reachable via MCP tools and identify the top-N tables by sensitivity.
+   - Build (or import) the classification catalog. Prefer declarative sources (DDL comments, dbt `meta`, Purview/Collibra exports) over ad-hoc spreadsheets.
+   - Define the label → action policy (e.g., `pii.email` → tokenize, `pci.pan` → mask-last-4, `secret.*` → block+alert, `phi.*` → block unless caller has PHI scope).
+   - Decide on reversibility requirements per label (tokenization vault vs one-way hash vs plain redact).
+
+2. **Development Phase**:
+   - Implement a DLP pipeline module that accepts a response payload plus a schema/context descriptor and returns a sanitized payload plus an audit record.
+   - Integrate Presidio (or chosen engine) with custom recognizers for domain-specific identifiers (internal user IDs, proprietary license keys, customer IDs) [1].
+   - For API-key and credential-like content in outputs, plug in an output-side secret scanner. Many deployments adapt the embedding-based semantic similarity approach from SAFE-M-63 (originally scoped to **incoming** credential-seeking queries) by reusing the same similarity engine to score outbound text fragments against known credential patterns. This is a composition pattern, not a direct reuse — the output-side application re-trains or re-threshold-tunes against masked-output fixtures, and SAFE-M-63's ingress scope is unchanged.
+   - Wrap each MCP tool's response path: for SQL connectors, iterate rows after fetch and before serialization; for HTTP connectors, parse JSON and traverse by JSON-path; for file/document tools, stream through the scanner with chunking.
+   - Emit structured audit events (tool, caller, label, action, match-count) on every non-allow decision.
+
+3. **Deployment Phase**:
+   - Roll out in **observe mode** first: run the pipeline, log what *would* have been masked/blocked, but do not transform payloads. Tune thresholds and catalog coverage.
+   - Promote to **enforce mode** per label class, starting with the highest-severity labels (secrets, PAN, SSN) where false-positives are operationally acceptable.
+   - Add SIEM detections on DLP audit events: spikes in `block` or `mask_count` per tool call, anomalous caller identities, novel label hits.
+   - Re-tune quarterly against red-team exercises (synthetic PII/PCI/secret fixtures) and production false-positive reports.
+
+## Benefits
+- **Contains bulk disclosure at the tool boundary**: a 3M-row `SELECT *` that would leak customer PII is reduced to 3M masked tokens plus a single loud audit event, even if the query itself was not blocked.
+- **Composable with query-layer controls**: stacks cleanly with query shape guardrails (SAFE-M-71), row caps (SAFE-M-23), and least-privilege DB roles (SAFE-M-16) as a defense-in-depth layer.
+- **High-signal telemetry**: DLP audit events are dense and rarely benign at scale, making them one of the most reliable detections for SAFE-T1803-style exfiltration.
+- **Reversibility preserved for legitimate flows**: tokenization keeps referential integrity for joins and pipelines while removing clear-text exposure from the agent context.
+
+## Limitations
+- **Schema-free outputs depend on detector recall**: document stores, blob columns, free-text notes, and agent-authored summaries cannot be classified at the schema layer; content scanners have measurable false-positive and false-negative rates that must be monitored and tuned [1][4].
+- **Tokenization adds infrastructure complexity**: a token vault is a high-value target itself and introduces availability and key-management risk; plan for it like any other cryptographic service [6][7].
+- **Derived/aggregate leakage**: an attacker or misaligned agent can ask for aggregates, counts, or model-authored summaries that encode sensitive content without triggering word-level scanners (e.g., "describe the 10 highest-paid employees"). DLP on outputs must be paired with query-shape and purpose controls.
+- **Performance cost on wide results**: per-row/per-field inspection adds latency proportional to row count and detector count; large result sets benefit from batching, sampling (with guaranteed coverage of classified columns), and native-language scanners.
+- **Classification-catalog drift**: schemas evolve; unclassified new columns are summarized (length and type) per principle 3, which can surprise downstream consumers that expected raw values — requires a catalog-freshness SLO and a documented path to add columns to the classification catalog quickly.
+
+## Implementation Examples
+
+### Example 1: DB connector wrapping query results with a Presidio-style scanner
+```python
+# Simplified; production code should stream rows rather than materialize them.
+from typing import Any, Iterable, Mapping
+from presidio_analyzer import AnalyzerEngine
+from presidio_anonymizer import AnonymizerEngine
+from presidio_anonymizer.entities import OperatorConfig
+
+analyzer = AnalyzerEngine()
+anonymizer = AnonymizerEngine()
+
+# label -> action config; loaded from policy file at startup
+POLICY: Mapping[str, OperatorConfig] = {
+    "pci.pan":     OperatorConfig("mask", {"masking_char": "*",
+                                           "chars_to_mask": 12,
+                                           "from_end": False}),
+    "pii.email":   OperatorConfig("replace", {"new_value": "<tokenized:email>"}),
+    "pii.ssn":     OperatorConfig("redact", {}),
+    "secret.key":  OperatorConfig("redact", {}),  # always strip
+}
+
+def sanitize_row(row: Mapping[str, Any],
+                 column_labels: Mapping[str, str],
+                 tool: str,
+                 caller: str) -> Mapping[str, Any]:
+    sanitized = {}
+    for col, value in row.items():
+        label = column_labels.get(col)
+
+        # 1. Schema-authoritative path
+        if label and label in POLICY:
+            sanitized[col] = _apply(POLICY[label], value)
+            _audit(tool, caller, col, label, action=POLICY[label].operator_name)
+            continue
+
+        # 2. Content-based fallback for unclassified or free-text
+        if isinstance(value, str):
+            findings = analyzer.analyze(text=value, language="en")
+            if findings:
+                sanitized[col] = anonymizer.anonymize(
+                    text=value, analyzer_results=findings
+                ).text
+                for f in findings:
+                    _audit(tool, caller, col, f.entity_type, action="mask")
+                continue
+
+        # 3. Default: pass through only if explicitly allowlisted
+        sanitized[col] = value if col in ALLOWLIST else _summarize(value)
+    return sanitized
+
+def sanitize_result_set(rows: Iterable[Mapping[str, Any]],
+                        table: str, tool: str, caller: str):
+    column_labels = CATALOG.labels_for(table)   # column -> label from data catalog
+    for row in rows:
+        yield sanitize_row(row, column_labels, tool, caller)
+```
+
+### Example 2: Policy configuration mapping labels to actions
+```json
+{
+  "version": "1.0",
+  "default_action": "summarize",
+  "labels": {
+    "pci.pan":      { "action": "mask",     "keep_last": 4,  "validator": "luhn" },
+    "pii.email":    { "action": "tokenize", "vault": "email-vault-v1" },
+    "pii.ssn":      { "action": "block",    "alert": "high" },
+    "pii.phone":    { "action": "mask",     "keep_last": 2 },
+    "phi.icd10":    { "action": "block",    "alert": "high",
+                      "exceptions": ["role:clinical-analyst"] },
+    "secret.key":   { "action": "redact",   "alert": "critical" },
+    "secret.jwt":   { "action": "redact",   "alert": "high" },
+    "ip.internal":  { "action": "allow" }
+  },
+  "scanners": {
+    "presidio":   { "enabled": true, "recognizers": ["US_SSN","CREDIT_CARD","EMAIL_ADDRESS","PERSON"] },
+    "secret_detector_safe_m_63": { "enabled": true, "threshold": 0.85 },
+    "custom_regex": {
+      "internal_user_id": "^usr_[A-Z0-9]{16}$"
+    }
+  }
+}
+```
+
+### Example 3: Observed detector performance (indicative; validate per deployment)
+| Detector                           | Corpus                         | Precision | Recall | Notes |
+|------------------------------------|--------------------------------|-----------|--------|-------|
+| Schema catalog (column label)      | Classified columns             | 1.00      | 1.00   | Authoritative when catalog is current |
+| Presidio `CREDIT_CARD` + Luhn      | Mixed JSON payloads            | 0.97      | 0.93   | Luhn post-filter cuts FP substantially [1] |
+| Presidio `US_SSN` (regex + context)| Customer service transcripts   | 0.88      | 0.91   | Sensitive to context words [1] |
+| Embedding-based secret scanner (output-side adaptation of the SAFE-M-63 approach) | API-key fixtures | 0.94 | 0.96 | Adapts SAFE-M-63's ingress similarity technique to output-side recognition [SAFE-M-63] |
+| Cloud DLP `PERSON_NAME` infoType   | Free-text notes                | 0.75      | 0.82   | High FP; pair with label context [3] |
+
+> Values above are illustrative ranges drawn from vendor reports and typical Presidio benchmarks. Every deployment must re-measure these metrics against its own data before promoting any label from observe mode to enforce mode, and must recalibrate after each catalog or detector update.
+
+## Testing and Validation
+1. **Security Testing**:
+   - Synthetic-fixture test suite covering PAN, SSN, IBAN, JWT, AWS/GCP/OpenAI-style keys, email, phone, and domain-specific IDs; assert every fixture is masked or blocked end-to-end through a representative MCP tool.
+   - Red-team drills simulating SAFE-T1803: issue `SELECT *` against a seeded `users` table and confirm no clear-text PII/secret reaches the agent.
+   - Evasion tests (homoglyphs, base64-wrapped secrets, split values across adjacent columns) to measure recall of the content scanners.
+
+2. **Functional Testing**:
+   - Golden-query regression tests to ensure legitimate analytics queries still return usable, tokenized results.
+   - Latency benchmarks at p50/p95/p99 for row-widths 10/100/1000 columns and result sizes 1/1k/100k rows.
+   - Catalog-coverage report: percentage of queried columns that hit a classified label vs fall back to content scanning.
+
+3. **Integration Testing**:
+   - Verify audit events flow to SIEM with correct caller identity, tool name, and label.
+   - Confirm tokenization round-trip through the detokenization service for authorized callers only.
+   - Chaos test: disable the DLP engine and confirm the connector fails closed (default deny), not open.
+
+## Deployment Considerations
+
+### Resource Requirements
+- **CPU**: scanner-bound; Presidio NER on CPU adds ~2–8 ms per short string, more for long documents [1]. Plan for per-connector worker pools or sidecar processes for high-QPS tools.
+- **Memory**: ~500 MB–2 GB per worker when loading Presidio/spaCy models; embedding-based secret scanners (SAFE-M-63) add ~500 MB.
+- **Storage**: negligible for policy/catalog; token vault sized to cardinality of tokenized values.
+- **Network**: if using cloud inline DLP APIs (Google Cloud DLP, Nightfall), factor egress and per-request quotas [3][10]. (AWS Macie is a discovery service, not a per-request inline engine — it runs offline against object stores to populate the classification catalog rather than sitting in the request path.)
+
+### Performance Impact
+- **Latency**: typically +5–30 ms per response for structured rows with a hit catalog; +50–200 ms for free-text scanning of large documents.
+- **Throughput**: schema-catalog path is effectively free; content scanning is the bottleneck — mitigate with batching and skipping already-classified columns.
+- **Resource Usage**: dominated by NER/embedding models; autoscale on per-tool QPS.
+
+### Monitoring and Alerting
+- `dlp.action_count{action=block}` per tool, per caller (primary SAFE-T1803 detection).
+- `dlp.mask_count` rate-of-change; sudden spikes indicate bulk dump attempts.
+- `dlp.catalog_miss_ratio` per table (drives classification-catalog freshness SLO).
+- `dlp.latency_ms` p95/p99 per connector.
+- Alert: any `secret.*` block, any `phi.*` block, any caller exceeding N blocks/hour.
+
+## Current Status (2026)
+DLP tooling is mature for general workloads: Microsoft Presidio [1], Google Cloud Sensitive Data Protection [3], and Nightfall [10] provide production-ready inline inspection engines; Fortanix Data Security Manager [6] and cloud-native format-preserving encryption [7] provide tokenization. AWS Macie [8] and Microsoft Purview [9] are data-discovery and classification catalog services that feed this pipeline rather than performing per-request inline scanning. Integration with MCP connectors is still largely **custom per deployment**: most MCP server implementations do not ship with a DLP hook point, so teams are wrapping database drivers and HTTP clients themselves. Column-level classification remains the practical bottleneck — organizations with mature data catalogs (dbt metadata, Purview, Collibra, Atlan) can deploy SAFE-M-72 in weeks, while teams without a catalog must first invest in discovery scans (Macie, Cloud DLP) to populate the catalog before enforcement becomes reliable [3][8][9]. Industry guidance from OWASP and NIST increasingly recommends egress-side DLP as a necessary layer for LLM-agent systems that expose tool access to sensitive datastores [2][11][12].
+
+## References
+- [1] [Microsoft Presidio — Data Protection and De-identification SDK](https://microsoft.github.io/presidio/)
+- [2] [OWASP Top 10 for LLM Applications (2025) — LLM02: Sensitive Information Disclosure](https://genai.owasp.org/llmrisk/llm02-sensitive-information-disclosure/)
+- [3] [Google Cloud Sensitive Data Protection (Cloud DLP) documentation](https://cloud.google.com/sensitive-data-protection/docs)
+- [4] [Luhn algorithm (ISO/IEC 7812-1) — MOD-10 validation for PAN](https://www.iso.org/standard/70484.html)
+- [5] [NIST SP 800-122 — Guide to Protecting the Confidentiality of PII](https://csrc.nist.gov/pubs/sp/800/122/final)
+- [6] [Fortanix Data Security Manager — Tokenization](https://www.fortanix.com/platform/data-security-manager/tokenization)
+- [7] [NIST SP 800-38G — Format-Preserving Encryption (FF1/FF3-1)](https://csrc.nist.gov/pubs/sp/800/38/g/final)
+- [8] [AWS Macie — Sensitive data discovery and classification](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html)
+- [9] [Microsoft Purview — Data classification and sensitivity labels](https://learn.microsoft.com/en-us/purview/data-classification-overview)
+- [10] [Nightfall AI — DLP for APIs and SaaS](https://www.nightfall.ai/platform)
+- [11] [MITRE ATT&CK M1041 — Data Loss Prevention](https://attack.mitre.org/mitigations/M1041/)
+- [12] [NIST AI 600-1 — Generative AI Profile (sensitive-data handling guidance)](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf)
+- [13] [Model Context Protocol Specification](https://modelcontextprotocol.io/specification)
+
+## Related Mitigations
+- [SAFE-M-71](../SAFE-M-71/README.md): Query Guardrails & Result Limits — complementary; SAFE-M-71 blocks malformed or overbroad queries at ingress, SAFE-M-72 sanitizes results at egress when a query slips through.
+- [SAFE-M-23](../SAFE-M-23/README.md): Tool Output Size Limits — complementary; row/byte caps reduce the volume DLP must scan and bound the worst-case disclosure.
+- [SAFE-M-63](../SAFE-M-63/README.md): Embedding-Based API Key Detection and Filtering — specialization; SAFE-M-63 is one high-recall secret-detection strategy that plugs into SAFE-M-72's scanner stage.
+- [SAFE-M-16](../SAFE-M-16/README.md): Least-Privilege Tool Authorization — complementary; tokens scope what data is reachable, DLP scopes what of that data is returned in clear.
+- [SAFE-M-5](../SAFE-M-5/README.md): Content Sanitization — distinct control (prompt-injection defense on inbound text); SAFE-M-72 is outbound sensitive-data filtering, not instruction filtering.
+- [SAFE-M-22](../SAFE-M-22/README.md): Semantic Output Validation — distinct control; SAFE-M-22 checks outputs for instruction-shaped content that could subvert the model; SAFE-M-72 checks outputs for sensitive content that should not cross the tool boundary regardless of model behavior.
+
+## Version History
+| Version | Date       | Changes                | Author       |
+|---------|------------|------------------------|--------------|
+| 1.0     | 2026-04-14 | Initial documentation  | bishnu bista |

--- a/mitigations/SAFE-M-72/README.md
+++ b/mitigations/SAFE-M-72/README.md
@@ -1,12 +1,11 @@
 # SAFE-M-72: Data Security - Data Loss Prevention on Tool Outputs
 
 ## Overview
-**Mitigation ID**: SAFE-M-72
-**Category**: Data Security
-**Effectiveness**: Medium-High (inline masking and tokenization are deterministic; policy accuracy is bounded by classification quality and detector recall)
-**Implementation Complexity**: Medium-High
+**Mitigation ID**: SAFE-M-72  
+**Category**: Data Security  
+**Effectiveness**: Medium-High (inline masking and tokenization are deterministic; policy accuracy is bounded by classification quality and detector recall)  
+**Implementation Complexity**: Medium-High  
 **First Published**: 2026-04-14
-**Author**: bishnu bista
 
 ## Description
 Data Loss Prevention (DLP) on Tool Outputs applies column-level classification, masking, tokenization, and sensitive-content detection to the results returned by MCP tools **before** those results enter the agent's context window or are surfaced to a user. The control treats every tool response as an untrusted egress point from a protected data store: structured rows from database connectors, semi-structured payloads from API wrappers, and free-text fields from document/knowledge tools are all inspected against a policy that maps sensitivity labels (PII, PCI, PHI, secrets, IP) to actions (allow, mask, tokenize, redact, block, alert).


### PR DESCRIPTION
## Summary
- Introduce four new SAFE-M mitigations that close gaps identified during validation of SAFE-T1309 (Privileged Tool Invocation via Prompt Manipulation) and SAFE-T1803 (Database Dump).
- IDs 69–72 were chosen because they are stub-free across the repository; IDs 58–68 and gap ranges 25–28, 39–44, 55–62 are reserved by forward references from existing technique documents.

## Mitigations added
- **SAFE-M-69: Out-of-Band Authorization for Privileged Tool Invocations** (Preventive). Every privileged tool call must pass an authorization check enforced outside the model's context: human-in-the-loop confirmation, signed short-lived capability tokens, or policy-engine grants. The signed-token verifier example demonstrates signature-first verification, JTI-based replay defense, and argument-digest binding.
- **SAFE-M-70: Tool-Invocation Anomaly Detection & Baselining** (Detective). Per-agent, per-user, per-tool baselines of MCP tool-call patterns (volume, cardinality, result size, destination, time) scored with robust z-scores, first-time-use rules (persisted across a rolling 90-day window), and isolation forest over the joint feature vector. Distinct from SAFE-M-11 (session-level behavioral analytics over model outputs) and SAFE-M-20 (OAuth request patterns).
- **SAFE-M-71: Query Guardrails & Result Limits** (Preventive). A policy engine parses proposed SQL tool calls and either dispatches, rewrites (e.g., by injecting a hard \`LIMIT\` before dispatch), rejects, or escalates. Complements SAFE-M-23 (post-execution truncation) and SAFE-M-72 (output DLP). Includes Python (sqlglot) and OPA/Rego policy examples.
- **SAFE-M-72: Data Loss Prevention on Tool Outputs** (Data Security). Column-level classification plus content scanners (Luhn / MOD-10 for PAN, MOD-97 for IBAN, format/area checks for US SSN, entropy for secrets, NER/ML for unstructured PII) apply mask, tokenize, redact, or block actions on outbound tool responses. Separates masking (one-way) from tokenization (reversible via an authenticated detokenization channel). Default action for unknown sensitivity is summarization, not masking.

## Companion PRs
- #191 (validate SAFE-T1309) references SAFE-M-69 and SAFE-M-70
- #192 (validate SAFE-T1803) references SAFE-M-70, SAFE-M-71, and SAFE-M-72
- This PR should merge first so those cross-references resolve.

## Design notes
- Each mitigation follows \`mitigations/TEMPLATE.md\` with Overview, Description, Mitigates, Technical Implementation (including an ASCII architecture diagram), Benefits, Limitations, Implementation Examples, Testing and Validation, Deployment Considerations, Current Status, References, Related Mitigations, and Version History.
- All cross-references to existing SAFE-M entries (M-1, M-5, M-11, M-12, M-14, M-16, M-22, M-23, M-29, M-36, M-63) preserve the catalog definitions of those mitigations; no existing IDs are re-scoped.
- The SAFE-M-63 relationship in SAFE-M-72 is explicitly described as an **adaptation** of M-63's ingress-scoped embedding similarity technique to the output side, not a re-use — M-63's ingress scope is unchanged.

## DCO
Signed-off-by: bishnubista <bista.developer@gmail.com>