### PR TITLE
fix(techniques): canonicalize zero-padded SAFE-M references

### DIFF
--- a/techniques/SAFE-T1704/README.md
+++ b/techniques/SAFE-T1704/README.md
@@ -430,4 +430,4 @@ tags:
 |---------|------|---------|--------|
 | 1.0 | 2025-12-04 | Initial documentation of Compromised-Server Pivot technique | rajivsth |
 | 2.0 | 2025-01-20 | Major revision: expanded attack vectors, detailed workspace pivot scenarios, comprehensive Sigma rules, and new mitigations (SAFE-M-58 through SAFE-M-68) | Pritika Bista |
-| 2.1 | 2025-02-17 | Merged unique content from v1.0: added T1570 mapping, arXiv research references, server-side context injection technique, original mitigations (SAFE-M-01/05/07/11/15), and additional IoCs | bishnubista |
+| 2.1 | 2025-02-17 | Merged unique content from v1.0: added T1570 mapping, arXiv research references, server-side context injection technique, original mitigations (SAFE-M-1/5/7/11/15), and additional IoCs | bishnubista |

--- a/techniques/SAFE-T1912/README.md
+++ b/techniques/SAFE-T1912/README.md
@@ -188,17 +188,17 @@ tags:
 ## Mitigation Strategies
 ### Preventive Controls
 
-- SAFE-M-003: Output Sanitization — Strip zero-width characters and detect suspicious encoding patterns.
+- SAFE-M-3: Output Sanitization — Strip zero-width characters and detect suspicious encoding patterns.
   
-- SAFE-M-014: Model Response Validation — Enforce schema validation to detect hidden or unexpected fields.
+- SAFE-M-14: Model Response Validation — Enforce schema validation to detect hidden or unexpected fields.
 
-- SAFE-M-021: Content Security Filtering — Reject high-entropy payloads inside text responses.
+- SAFE-M-21: Content Security Filtering — Reject high-entropy payloads inside text responses.
 
 ### Detective Controls
 
-- SAFE-M-009: Steganography Detection Layer — Scan for entropy anomalies in responses.
+- SAFE-M-9: Steganography Detection Layer — Scan for entropy anomalies in responses.
 
-- SAFE-M-011: Logging & Telemetry Controls — Record responses and highlight suspicious patterns.
+- SAFE-M-11: Logging & Telemetry Controls — Record responses and highlight suspicious patterns.
 
 ## Response Procedures
 


### PR DESCRIPTION
## Summary

Six \`SAFE-M-NN\` references in two technique READMEs use zero-padded variants that don't resolve to the canonical mitigation files. This PR corrects them to the canonical form (\`SAFE-M-N\`, no zero padding — matching the \`mitigations/\` directory naming).

## Changes

**\`techniques/SAFE-T1912/README.md\`** — preventive/detective control list:

| Before | After |
|---|---|
| SAFE-M-003 | SAFE-M-3 |
| SAFE-M-009 | SAFE-M-9 |
| SAFE-M-011 | SAFE-M-11 |
| SAFE-M-014 | SAFE-M-14 |
| SAFE-M-021 | SAFE-M-21 |

**\`techniques/SAFE-T1704/README.md\`** — Version History row, slash-list shorthand:

| Before | After |
|---|---|
| \`SAFE-M-01/05/07/11/15\` | \`SAFE-M-1/5/7/11/15\` |

## Verification

\`\`\`bash
grep -rhoE 'SAFE-M-[0-9]+' techniques/ | sort -u > /tmp/refs.txt
ls mitigations/ | grep -oE 'SAFE-M-[0-9]+' | sort -u > /tmp/have.txt
comm -23 /tmp/refs.txt /tmp/have.txt   # dangling references
\`\`\`

- Before this PR: 38 dangling \`SAFE-M-NN\` references in the corpus.
- After this PR: 32 dangling references (the 6 zero-pad fixes resolve cleanly to existing canonical mitigations).

## Scope

This PR is intentionally narrow — only the mechanical canonicalization. The remaining 32 dangling references include ID collisions (multiple techniques claiming the same \`SAFE-M-NN\` for different mitigation concepts) and orphan \`SAFE-M-101..106\` / \`SAFE-M-201..203\` numbering schemes. Those require taxonomy decisions and will be addressed in separate scoped PRs rather than bundled here.

## Test plan

- [x] \`grep\` audit confirms 6 zero-pad refs reduced to 0
- [x] DCO sign-off on commit
- [x] No code/yaml changes — markdown text only; no detection-rule or schema impact