### PR TITLE
fix(SAFE-T1408): neutralize orphan SAFE-M-101..106 / 201..203 references

### DIFF
--- a/techniques/SAFE-T1408/README.md
+++ b/techniques/SAFE-T1408/README.md
@@ -151,17 +151,17 @@ tags:
 ## Mitigation Strategies
 
 ### Preventive Controls
-1. **SAFE-M-101: Disable Implicit Flow**: Configure authorization server to reject `response_type=token`.  
-2. **SAFE-M-102: Enforce PKCE**: Require PKCE for all public clients.  
-3. **SAFE-M-103: Client Registration Hardening**: Allow only authorization code flow with PKCE.  
-4. **SAFE-M-104: HTTP Message Signatures**: Use RFC 9421 to sign requests, preventing parameter tampering and downgrade attempts.  
-5. **SAFE-M-105: Audience and Scope Restriction**: Bind tokens to specific resources and minimize privileges.  
-6. **SAFE-M-106: Secure Token Storage**: Ensure tokens are never stored in URLs, logs, or insecure browser storage.
+1. **Disable Implicit Flow** *(canonical mitigation pending)*: Configure authorization server to reject `response_type=token`.  
+2. **Enforce PKCE** *(canonical mitigation pending)*: Require PKCE for all public clients.  
+3. **Client Registration Hardening** *(canonical mitigation pending)*: Allow only authorization code flow with PKCE.  
+4. **HTTP Message Signatures** *(canonical mitigation pending)*: Use RFC 9421 to sign requests, preventing parameter tampering and downgrade attempts.  
+5. **Audience and Scope Restriction** *(canonical mitigation pending)*: Bind tokens to specific resources and minimize privileges.  
+6. **Secure Token Storage** *(canonical mitigation pending)*: Ensure tokens are never stored in URLs, logs, or insecure browser storage.
 
 ### Detective Controls
-1. **SAFE-M-201: Log Monitoring**: Detect requests with implicit flow parameters.  
-2. **SAFE-M-202: Token Exposure Alerts**: Alert when tokens appear in URL fragments.  
-3. **SAFE-M-203: Replay Detection**: Monitor for repeated use of the same token across multiple MCP servers.
+1. **Log Monitoring** *(canonical mitigation pending)*: Detect requests with implicit flow parameters.  
+2. **Token Exposure Alerts** *(canonical mitigation pending)*: Alert when tokens appear in URL fragments.  
+3. **Replay Detection** *(canonical mitigation pending)*: Monitor for repeated use of the same token across multiple MCP servers.
 
 ### Response Procedures
 1. **Immediate Actions**:  


### PR DESCRIPTION
## Summary

Nine \`SAFE-M-NN\` references in \`techniques/SAFE-T1408/README.md\` use 100-series and 200-series numbering schemes, neither of which exists in the canonical \`mitigations/\` directory (every authored mitigation is in the SAFE-M-1..72 range). The references appear to be a parallel local numbering scheme that was never promoted to canonical files.

## Changes

\`techniques/SAFE-T1408/README.md\` — Mitigation Strategies section.

Each \`**SAFE-M-NN: Title**: body\` line is rewritten to \`**Title** *(canonical mitigation pending)*: body\`. Descriptive titles and bodies are preserved so the original author's intent is intact.

| Section | IDs neutralized |
|---|---|
| Preventive Controls | M-101 *Disable Implicit Flow* · M-102 *Enforce PKCE* · M-103 *Client Registration Hardening* · M-104 *HTTP Message Signatures* · M-105 *Audience and Scope Restriction* · M-106 *Secure Token Storage* |
| Detective Controls | M-201 *Log Monitoring* · M-202 *Token Exposure Alerts* · M-203 *Replay Detection* |

## Note for follow-up

A few of these may correspond to existing canonical mitigations and could be re-linked properly in a separate scoped PR:

- \"Enforce PKCE\" overlaps with \`mitigations/SAFE-M-38\` *PKCE Enforcement*
- \"Log Monitoring\" overlaps with \`mitigations/SAFE-M-12\` *Audit Logging*

Re-linking is intentionally deferred — that's a taxonomy decision rather than a cleanup, and bundling it here would obscure the mechanical scope of this PR.

## Verification

\`\`\`bash
grep -rhoE 'SAFE-M-[0-9]+' techniques/ | sort -u > /tmp/refs.txt
ls mitigations/ | grep -oE 'SAFE-M-[0-9]+' | sort -u > /tmp/have.txt
comm -23 /tmp/refs.txt /tmp/have.txt
\`\`\`

- Before this PR: 32 dangling references (post-#199).
- After this PR: 23 dangling references — only the collision-cluster IDs remain (M-25..28, 39..44, 55..67), each to be addressed in its own scoped PR.

## Scope

Second of several scoped PRs cleaning up dangling SAFE-M-NN references. #199 (merged) handled zero-padding canonicalization. The remaining 23 dangling references are ID collisions across multiple techniques and require taxonomy decisions, so each cluster will be its own PR.

## Test plan

- [x] Audit grep confirms 9 orphan-series refs reduced to 0
- [x] DCO sign-off on commit
- [x] No code/yaml changes — markdown text only; no detection-rule or schema impact