### PR TITLE
docs: add SAFE-MCP maintainers list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 | ---------------- | ------------------------------------------------------------------------------------------ |
 | **Mailing List** | [openssf-sig-safe-mcp@lists.openssf.org](https://lists.openssf.org/g/openssf-sig-safe-mcp) |
 | **SIG Leads**    | Sarah Evans; Frederick Kautz                                                               |
+| **Maintainers**  | Bishnu Bista; Sarah Evans; Frederick Kautz                                                 |
 | **Meeting Time** | 1:00 PM PT (PST/PDT) Bi-Weekly                                                             |
 | **Slack**        | OpenSSF #sig-safe-mcp                                                                      |
 


### PR DESCRIPTION
## Summary
- Add a **Maintainers** row to the README info table listing Bishnu Bista, Sarah Evans, and Frederick Kautz.

## Test plan
- [x] Visual check of the rendered README table on GitHub