### PR TITLE
Relicense mitigations to Community Specification License 1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,13 @@ This project follows the [CNCF Code of Conduct](CODE_OF_CONDUCT.md). By particip
 
 ## Licensing
 
-This project uses a dual licensing structure:
+This project uses a multi-license structure:
 
-- **Documentation** (including threat descriptions, markdown files, and written content) is licensed under [CC BY 4.0](LICENSE-CC-BY-4.0)
+- **Techniques and general documentation** (including threat descriptions, markdown files, and written content outside `mitigations/`) are licensed under [CC BY 4.0](LICENSE-CC-BY-4.0)
+- **Mitigations** (`mitigations/` and `MITIGATIONS.md`): new contributions are licensed under the [Community Specification License 1.0](LICENSE-CSL-1.0). Mitigation content contributed on or before 2026-06-10 remains under [CC BY 4.0](LICENSE-CC-BY-4.0) until the original contributors sign off on relicensing or the content is rewritten.
 - **Code** (including scripts, detection rules, and software) is licensed under [Apache 2.0](LICENSE-APACHE-2.0)
 
-By contributing, you agree that your contributions will be licensed under the applicable license based on the type of content.
+By contributing, you agree that your contributions will be licensed under the applicable license based on the type and location of the content. In particular, by contributing to the mitigations you agree to the terms of the Community Specification License 1.0.
 
 ## Developer Certificate of Origin (DCO)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,40 @@
-SAF-MCP Dual License
+SAF-MCP Licensing
 
-This project uses a dual licensing structure:
+This project uses a multi-license structure based on the type of content:
 
-1. Documentation License
-   All documentation, including but not limited to markdown files, technique descriptions,
-   and written content, is licensed under the Creative Commons Attribution 4.0 International
-   License (CC BY 4.0).
-   
+1. Techniques and General Documentation
+   All technique descriptions (techniques/), and all other documentation and
+   written content not covered by sections 2 or 3 below, are licensed under
+   the Creative Commons Attribution 4.0 International License (CC BY 4.0).
+
    Full license text: https://creativecommons.org/licenses/by/4.0/
    License file: LICENSE-CC-BY-4.0
-   
-2. Code License
-   All code, including but not limited to scripts, detection rules, and software implementations,
-   is licensed under the Apache License, Version 2.0.
-   
+
+2. Mitigations
+   New contributions to the mitigations (mitigations/ and MITIGATIONS.md) are
+   licensed under the Community Specification License 1.0 (CSL 1.0).
+
+   Full license text: https://github.com/CommunitySpecification/1.0
+   License file: LICENSE-CSL-1.0
+   Specification scope: mitigations/SCOPE.md
+   Notices (license acceptance, withdrawals, exclusions): mitigations/NOTICES.md
+
+   Transition note: Mitigation content contributed on or before 2026-06-10
+   was contributed under CC BY 4.0 and remains licensed under CC BY 4.0.
+   That existing content will remain CC BY 4.0 until the project obtains
+   relicensing sign-off from the original contributors or the content is
+   rewritten. All mitigation contributions after that date are accepted
+   under CSL 1.0 only.
+
+3. Code License
+   All code, including but not limited to scripts, detection rules, and
+   software implementations, is licensed under the Apache License,
+   Version 2.0.
+
    Full license text: https://www.apache.org/licenses/LICENSE-2.0
    License file: LICENSE-APACHE-2.0
 
 The full text of each license is provided in the respective files within this repository.
 
 By contributing to this project, you agree that your contributions will be licensed under
-the applicable license based on the type of content (documentation or code).
+the applicable license based on the type and location of the content, as described above.

--- a/LICENSE-CSL-1.0
+++ b/LICENSE-CSL-1.0
@@ -1,0 +1,99 @@
+# Community Specification License 1.0
+
+**The Purpose of this License.**  This License sets forth the terms under which 1) Contributor will participate in and contribute to the development of specifications, standards, best practices, guidelines, and other similar materials under this Working Group, and 2) how the materials developed under this License may be used.  It is not intended for source code.  Capitalized terms are defined in the License’s last section.
+
+**1.	Copyright.**
+
+**1.1.	Copyright License.**  Contributor grants everyone a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) copyright license, without any obligation for accounting, to reproduce, prepare derivative works of, publicly display, publicly perform, and distribute any materials it submits to the full extent of its copyright interest in those materials. Contributor also acknowledges that the Working Group may exercise copyright rights in the Specification, including the rights to submit the Specification to another standards organization.
+
+**1.2.	Copyright Attribution.**  As a condition, anyone exercising this copyright license must include attribution to the Working Group in any derivative work based on materials developed by the Working Group.  That attribution must include, at minimum, the material’s name, version number, and source from where the materials were retrieved.  Attribution is not required for implementations of the Specification.
+
+**2.	Patents.**
+
+**2.1.	Patent License.**
+
+**2.1.1.	As a Result of Contributions.**
+
+**2.1.1.1.	As a Result of Contributions to Draft Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims in 1) Contributor’s Contributions and 2) to the Draft Specification that is within Scope as of the date of that Contribution, in both cases for Licensee’s Implementation of the Draft Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.1.2.	For Approved Specifications.**  Contributor grants Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims included in the Approved Specification that are within Scope for Licensee’s Implementation of the Approved Specification, except for those patent claims excluded by Contributor under Section 3.
+
+**2.1.2.	Patent Grant from Licensee.**  Licensee grants each other Licensee a non-sublicensable, perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as expressly stated in this License) license to its Necessary Claims for its Implementation, except for those patent claims excluded under Section 3.
+
+**2.1.3.	Licensee Acceptance.**  The patent grants set forth in Section 2.1 extend only to Licensees that have indicated their agreement to this License as follows:
+
+**2.1.3.1.	Source Code Distributions.**  For distribution in source code, by including this License in the root directory of the source code with the Implementation;
+
+**2.1.3.2.	Non-Source Code Distributions.**  For distribution in any form other than source code, by including this License in the documentation, legal notices, via notice in the software, and/or other written materials provided with the Implementation; or
+
+**2.1.3.3.	Via Notices.md.**  By issuing pull request or commit to the Specification’s repository’s Notices.md file by the Implementer’s authorized representative, including the Implementer’s name, authorized individual and system identifier, and Specification version.
+
+**2.1.4.	Defensive Termination.**  If any Licensee files or maintains a claim in a court asserting that a Necessary Claim is infringed by an Implementation, any licenses granted under this License to the Licensee are immediately terminated unless 1) that claim is directly in response to a claim against Licensee regarding an Implementation, or 2) that claim was brought to enforce the terms of this License, including intervention in a third-party action by a Licensee.
+
+**2.1.5.	Additional Conditions.**  This License is not an assurance (i) that any of Contributor’s copyrights or issued patent claims cover an Implementation of the Specification or are enforceable or (ii) that an Implementation of the Specification would not infringe intellectual property rights of any third party.
+
+**2.2.	Patent Licensing Commitment.**  In addition to the rights granted in Section 2.1, Contributor agrees to grant everyone a no charge, royalty-free license on reasonable and non-discriminatory terms to Contributor’s Necessary Claims that are within Scope for:
+1) Implementations of a Draft Specification, where such license applies only to those Necessary Claims infringed by implementing Contributor's Contribution(s) included in that Draft Specification, and
+2) Implementations of the Approved Specification.
+
+This patent licensing commitment does not apply to those claims subject to Contributor’s Exclusion Notice under Section 3.
+
+**2.3.	Effect of Withdrawal.**  Contributor may withdraw from the Working Group by issuing a pull request or commit providing notice of withdrawal to the Working Group repository’s Notices.md file.  All of Contributor’s existing commitments and obligations with respect to the Working Group up to the date of that withdrawal notice will remain in effect, but no new obligations will be incurred.
+
+**2.4.	Binding Encumbrance.**  This License is binding on any future owner, assignee, or party who has been given the right to enforce any Necessary Claims against third parties.
+
+**3.	Patent Exclusion.**
+
+**3.1.	As a Result of Contributions.**  Contributor may exclude Necessary Claims from its licensing commitments incurred under Section 2.1.1 by issuing an Exclusion Notice within 45 days of the date of that Contribution.  Contributor may not issue an Exclusion Notice for any material that has been included in a Draft Deliverable for more than 45 days prior to the date of that Contribution.
+
+**3.2.	As a Result of a Draft Specification Becoming an Approved Specification.**  Prior to the adoption of a Draft Specification as an Approved Specification, Contributor may exclude Necessary Claims from its licensing commitments under this Agreement by issuing an Exclusion Notice.  Contributor may not issue an Exclusion Notice for patents that were eligible to have been excluded pursuant to Section 3.1.
+
+**4.	Source Code License.**  Any source code developed by the Working Group is solely subject the source code license included in the Working Group’s repository for that code.  If no source code license is included, the source code will be subject to the MIT License.
+
+**5.	No Other Rights.**  Except as specifically set forth in this License, no other express or implied patent, trademark, copyright, or other rights are granted under this License, including by implication, waiver, or estoppel.
+
+**6.	Antitrust Compliance.**  Contributor acknowledge that it may compete with other participants in various lines of business and that it is therefore imperative that they and their respective representatives act in a manner that does not violate any applicable antitrust laws and regulations.  This License does not restrict any Contributor from engaging in similar specification development projects. Each Contributor may design, develop, manufacture, acquire or market competitive deliverables, products, and services, and conduct its business, in whatever way it chooses.  No Contributor is obligated to announce or market any products or services.  Without limiting the generality of the foregoing, the Contributors agree not to have any discussion relating to any product pricing, methods or channels of product distribution, division of markets, allocation of customers or any other topic that should not be discussed among competitors under the auspices of the Working Group.
+
+**7.	Non-Circumvention.**  Contributor agrees that it will not intentionally take or willfully assist any third party to take any action for the purpose of circumventing any obligations under this License.
+
+**8.	Representations, Warranties and Disclaimers.**
+
+**8.1.  Representations, Warranties and Disclaimers.**  Contributor and Licensee represents and warrants that 1) it is legally entitled to grant the rights set forth in this License and 2) it will not intentionally include any third party materials in any Contribution unless those materials are available under terms that do not conflict with this License.  IN ALL OTHER RESPECTS ITS CONTRIBUTIONS ARE PROVIDED "AS IS." The entire risk as to implementing or otherwise using the Contribution or the Specification is assumed by the implementer and user. Except as stated herein, CONTRIBUTOR AND LICENSEE EXPRESSLY DISCLAIM ANY WARRANTIES (EXPRESS, IMPLIED, OR OTHERWISE), INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, NON-INFRINGEMENT, FITNESS FOR A PARTICULAR PURPOSE, CONDITIONS OF QUALITY, OR TITLE, RELATED TO THE CONTRIBUTION OR THE SPECIFICATION.  IN NO EVENT WILL ANY PARTY BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. Any obligations regarding the transfer, successors in interest, or assignment of Necessary Claims will be satisfied if Contributor or Licensee notifies the transferee or assignee of any patent that it knows contains Necessary Claims or necessary claims under this License. Nothing in this License requires Contributor to undertake a patent search. If Contributor is 1) employed by or acting on behalf of an employer, 2) is making a Contribution under the direction or control of a third party, or 3) is making the Contribution as a consultant, contractor, or under another similar relationship with a third party, Contributor represents that they have been authorized by that party to enter into this License on its behalf.
+
+**8.2.  Distribution Disclaimer.**  Any distributions of technical information to third parties must include a notice materially similar to the following: “THESE MATERIALS ARE PROVIDED “AS IS.” The Contributors and Licensees expressly disclaim any warranties (express, implied, or otherwise), including implied warranties of merchantability, non-infringement, fitness for a particular purpose, or title, related to the materials.  The entire risk as to implementing or otherwise using the materials is assumed by the implementer and user. IN NO EVENT WILL THE CONTRIBUTORS OR LICENSEES BE LIABLE TO ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.”
+
+**9.	Definitions.**
+
+**9.1.	Affiliate.** “Affiliate” means an entity that directly or indirectly Controls, is Controlled by, or is under common Control of that party.
+
+**9.2.	Approved Specification.**  “Approved Specification” means the final version and contents of any Draft Specification designated as an Approved Specification as set forth in the accompanying Governance.md file.
+
+**9.3.	Contribution.**  “Contribution” means any original work of authorship, including any modifications or additions to an existing work, that Contributor submits for inclusion in a Draft Specification, which is included in a Draft Specification or Approved Specification.
+
+**9.4.	Contributor.** “Contributor” means any person or entity that has indicated its acceptance of the License 1) by making a Contribution to the Specification, or 2) by entering into the Community Specification Contributor License Agreement for the Specification.  Contributor includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.5.	Control.**  “Control” means direct or indirect control of more than 50% of the voting power to elect directors of that corporation, or for any other entity, the power to direct management of such entity.
+
+**9.6.	Draft Specification.**  “Draft Specification” means all versions of the material (except an Approved Specification) developed by this Working Group for the purpose of creating, commenting on, revising, updating, modifying, or adding to any document that is to be considered for inclusion in the Approved Specification.
+
+**9.7.	Exclusion Notice.**  “Exclusion Notice” means a written notice made by making a pull request or commit to the repository’s Notices.md file that identifies patents that Contributor is excluding from its patent licensing commitments under this License.  The Exclusion Notice for issued patents and published applications must include the Draft Specification’s name, patent number(s) or title and application number(s), as the case may be, for each of the issued patent(s) or pending patent application(s) that the Contributor is excluding from the royalty-free licensing commitment set forth in this License.  If an issued patent or pending patent application that may contain Necessary Claims is not set forth in the Exclusion Notice, those Necessary Claims shall continue to be subject to the licensing commitments under this License.  The Exclusion Notice for unpublished patent applications must provide either: (i) the text of the filed application; or (ii) identification of the specific part(s) of the Draft Specification whose implementation makes the excluded claim a Necessary Claim.  If (ii) is chosen, the effect of the exclusion will be limited to the identified part(s) of the Draft Specification.
+
+**9.8.	Implementation.**  “Implementation” means making, using, selling, offering for sale, importing or distributing any implementation of the Specification 1) only to the extent it implements the Specification and 2) so long as all required portions of the Specification are implemented.
+
+**9.9.	License.**  “License” means this Community Specification License.
+
+**9.10.	Licensee.**  “Licensee” means any person or entity that has indicated its acceptance of the License as set forth in Section 2.1.3.  Licensee includes its Affiliates, assigns, agents, and successors in interest.
+
+**9.11.	Necessary Claims.**  “Necessary Claims” are those patent claims, if any, that a party owns or controls, including those claims later acquired, that are necessary to implement the required portions (including the required elements of optional portions) of the Specification that are described in detail and not merely referenced in the Specification.
+
+**9.12.	Specification.**  “Specification” means a Draft Specification or Approved Specification included in the Working Group’s repository subject to this License, and the version of the Specification implemented by the Licensee.
+
+**9.13.	Scope.**  “Scope” has the meaning as set forth in the accompanying Scope.md file included in this Specification’s repository. Changes to Scope do not apply retroactively.  If no Scope is provided, each Contributor’s Necessary Claims are limited to that Contributor’s Contributions.
+
+**9.14.	Working Group.**  “Working Group” means this project to develop specifications, standards, best practices, guidelines, and other similar materials under this License.
+
+
+
+*The text of this Community Specification License is Copyright 2020 Joint Development Foundation and is licensed under the Creative Commons Attribution 4.0 International License available at https://creativecommons.org/licenses/by/4.0/.*
+
+SPDX-License-Identifier: CC-BY-4.0

--- a/MITIGATIONS.md
+++ b/MITIGATIONS.md
@@ -4,6 +4,10 @@
 
 SAF-MCP mitigations are security controls designed to protect Model Context Protocol (MCP) implementations from the attack techniques documented in our framework. Each mitigation is categorized by type and effectiveness, with clear mappings to the techniques it addresses.
 
+### Licensing
+
+New contributions to the mitigations are licensed under the [Community Specification License 1.0](LICENSE-CSL-1.0). Mitigation content contributed on or before 2026-06-10 remains under [CC BY 4.0](LICENSE-CC-BY-4.0) until the original contributors sign off on relicensing or the content is rewritten. See [LICENSE](LICENSE) for the full licensing structure.
+
 ### Mitigation Categories
 
 - **Architectural Defense**: Fundamental design patterns that prevent entire classes of attacks

--- a/README.md
+++ b/README.md
@@ -174,3 +174,13 @@ The SAF-MCP framework defines 14 tactics that align with the MITRE ATT&CK method
 - Map these techniques to your specific MCP deployment for risk assessment
 - Prioritize mitigation based on your threat model and the techniques most relevant to your environment
 - Regular review as new techniques emerge in the rapidly evolving MCP threat landscape
+
+## License
+
+This project uses a multi-license structure based on the type of content:
+
+- **Techniques and general documentation** are licensed under [CC BY 4.0](LICENSE-CC-BY-4.0)
+- **Mitigations** (`mitigations/` and `MITIGATIONS.md`): new contributions are licensed under the [Community Specification License 1.0](LICENSE-CSL-1.0); mitigation content contributed on or before 2026-06-10 remains under [CC BY 4.0](LICENSE-CC-BY-4.0) until the original contributors sign off on relicensing or the content is rewritten
+- **Code** (scripts, detection rules, and software) is licensed under [Apache 2.0](LICENSE-APACHE-2.0)
+
+See [LICENSE](LICENSE) for full details, [mitigations/SCOPE.md](mitigations/SCOPE.md) for the mitigation specification's scope, and [mitigations/NOTICES.md](mitigations/NOTICES.md) for Community Specification License notices.

--- a/mitigations/NOTICES.md
+++ b/mitigations/NOTICES.md
@@ -1,0 +1,73 @@
+# Notices
+
+This file applies to the SAF-MCP Mitigations specification (`mitigations/`
+and `MITIGATIONS.md`), which is developed under the
+[Community Specification License 1.0](../LICENSE-CSL-1.0).
+
+## Code of Conduct
+
+This project follows the [CNCF Code of Conduct](../CODE_OF_CONDUCT.md).
+
+Contact for Code of Conduct issues or inquiries:
+
+- Frederick F. Kautz IV <frederick@kautz.dev>
+
+## License Acceptance
+
+Per Community Specification License 1.0 Section 2.1.3.3, Licensees may
+indicate their acceptance of the Community Specification License by issuing a
+pull request to this NOTICES.md file, including the Licensee’s name,
+authorized individuals' names and system identifier (e.g. GitHub ID), and
+specification version.
+
+A Licensee may consent to accepting the current Community Specification
+License version or any future version of the Community Specification License
+by indicating "or later" after their specification version.
+
+---------------------------------------------------------------------------------
+
+Licensee’s name:
+
+Authorized individual and system identifier:
+
+Specification version:
+
+---------------------------------------------------------------------------------
+
+## Withdrawals
+
+Name of party withdrawing:
+
+Date of withdrawal:
+
+---------------------------------------------------------------------------------
+
+## Exclusions
+
+This section includes any Exclusion Notices made against a Draft Deliverable
+or Approved Deliverable as set forth in the Community Specification License.
+Each Exclusion Notice must include the following information:
+
+- Name of party making the Exclusion Notice:
+
+- Name of patent owner:
+
+- Specification:
+
+- Version number:
+
+**For issued patents and published patent applications:**
+
+(i) patent number(s) or title and application number(s), as the case may be:
+
+(ii) identification of the specific part(s) of the Specification whose
+implementation makes the excluded claim a Necessary Claim.
+
+**For unpublished patent applications must provide either:**
+
+(i) the text of the filed application; or
+
+(ii) identification of the specific part(s) of the Specification whose
+implementation makes the excluded claim a Necessary Claim.
+
+---------------------------------------------------------------------------------

--- a/mitigations/SCOPE.md
+++ b/mitigations/SCOPE.md
@@ -1,0 +1,24 @@
+# Scope
+
+The scope of this Working Group is the development and maintenance of the
+SAF-MCP Mitigations specification: the catalog of security mitigations
+(SAF-M identifiers) for the Model Context Protocol (MCP) ecosystem,
+consisting of the contents of the `mitigations/` directory and the
+`MITIGATIONS.md` reference document in the SAF-MCP repository.
+
+This includes:
+
+- Mitigation identifiers (SAF-M-*), names, and descriptions
+- Mitigation categories and effectiveness ratings
+- Implementation guidance, considerations, and examples within mitigation
+  documents
+- Mappings between mitigations and SAF-MCP techniques (SAF-T identifiers)
+
+This Scope does not include:
+
+- The SAF-MCP techniques documentation (`techniques/`), which is licensed
+  under CC BY 4.0
+- Code, including scripts, detection rules, and software implementations,
+  which is licensed under the Apache License, Version 2.0
+
+Any changes of Scope are not retroactive.


### PR DESCRIPTION
## Summary

- Mitigations (`mitigations/` and `MITIGATIONS.md`) now accept **new contributions under the [Community Specification License 1.0](https://github.com/CommunitySpecification/1.0)**; techniques and general documentation remain CC BY 4.0, and code remains Apache 2.0
- **Transition note:** mitigation content contributed on or before 2026-06-10 was contributed under CC BY 4.0 and remains CC BY 4.0 until the original contributors sign off on relicensing or the content is rewritten
- Adds the CSL 1.0 license text (`LICENSE-CSL-1.0`), a specification scope statement (`mitigations/SCOPE.md`), and `mitigations/NOTICES.md` for license acceptance, withdrawals, and patent exclusion notices per CSL 1.0 §2.1.3.3
- Updates `LICENSE`, `CONTRIBUTING.md`, `MITIGATIONS.md`, and the README to document the new structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)