### PR TITLE
Add SAF-M-74: Per-Invocation Capability Brokering

### DIFF
--- a/MITIGATIONS.md
+++ b/MITIGATIONS.md
@@ -41,6 +41,7 @@ New contributions to the mitigations are licensed under the [Community Specifica
 | [SAF-M-7](mitigations/SAF-M-7/README.md) | Content Rendering Parity | UI Security | Medium-High |
 | [SAF-M-8](mitigations/SAF-M-8/README.md) | Visual Validation | UI Security | Medium |
 | [SAF-M-9](mitigations/SAF-M-9/README.md) | Sandboxed Testing | Isolation and Containment | High |
+| [SAF-M-74](mitigations/SAF-M-74/README.md) | Per-Invocation Capability Brokering | Isolation and Containment | High |
 | [SAF-M-10](mitigations/SAF-M-10/README.md) | Automated Scanning | Detective Control | Medium |
 | [SAF-M-11](mitigations/SAF-M-11/README.md) | Behavioral Monitoring | Detective Control | High |
 | [SAF-M-12](mitigations/SAF-M-12/README.md) | Audit Logging | Detective Control | Medium-High |
@@ -83,9 +84,9 @@ New contributions to the mitigations are licensed under the [Community Specifica
 
 ## Summary Statistics
 
-- **Total Mitigations**: 47
-- **High Effectiveness**: 26 (55%)
-- **Medium-High Effectiveness**: 15 (32%)
+- **Total Mitigations**: 48
+- **High Effectiveness**: 27 (56%)
+- **Medium-High Effectiveness**: 15 (31%)
 - **Medium Effectiveness**: 6 (13%)
 - **Low Effectiveness**: 0 (0%)
 
@@ -103,7 +104,7 @@ New contributions to the mitigations are licensed under the [Community Specifica
 | Supply Chain Security | 4 |
 | Data Security | 2 |
 | Architectural Control | 4 |
-| Isolation and Containment | 1 |
+| Isolation and Containment | 2 |
 | Risk Management | 1 |
 | Human Factors | 1 |
 

--- a/mitigations/SAF-M-74/README.md
+++ b/mitigations/SAF-M-74/README.md
@@ -1,0 +1,128 @@
+# SAF-M-74: Per-Invocation Capability Brokering
+
+## Overview
+**Mitigation ID**: SAF-M-74  
+**Category**: Isolation and Containment  
+**Effectiveness**: High  
+**Implementation Complexity**: Medium  
+**First Published**: 2026-06-15
+
+## Description
+Per-Invocation Capability Brokering interposes a supervisor between an MCP server and the host OS for every individual tool call. Rather than granting a tool server a static set of OS-level permissions at startup, the broker enforces a declared capability manifest on a per-call basis, specifying exactly which filesystem paths, network destinations, and syscalls a given tool is permitted to access during that invocation and no others.
+
+The broker is implemented as an embeddable library, not a sidecar or external gateway, so it ships as a dependency of the MCP server itself with no additional infrastructure required. On Linux, filesystem access control is enforced by Linux Landlock LSM and syscall filtering by seccomp. Invocation attestation is provided via Sigstore, producing a signed, tamper-evident record of the capability set active at the time of each tool call. Credential access during tool execution uses a phantom token model: the tool receives a short-lived, single-use token scoped to the current invocation, and the underlying credential is never exposed to the tool server process.
+
+## Mitigates
+- [SAF-T1302](../../techniques/SAF-T1302/README.md): High-Privilege Tool Abuse — Landlock and seccomp enforce a per-call capability ceiling; a tool cannot reach paths or syscalls outside its declared manifest even when an agent is tricked into invoking it.
+- [SAF-T1303](../../techniques/SAF-T1303/README.md): Container Sandbox Escape via Runtime Exec — does not prevent the underlying runtime vulnerability; after a boundary violation, per-invocation Landlock and seccomp profiles limit which host paths and syscalls remain reachable.
+- [SAF-T1304](../../techniques/SAF-T1304/README.md): Credential Relay Chain — phantom tokens are scoped to one invocation and expire on completion, reducing the window for relaying stolen credentials to higher-privilege tools.
+- [SAF-T1101](../../techniques/SAF-T1101/README.md): Command Injection — does not prevent injection; per-invocation seccomp and binary allowlists confine what an injected command can spawn or access, reducing blast radius.
+- [SAF-T1111](../../techniques/SAF-T1111/README.md): AI Agent CLI Weaponization — where weaponization flows through MCP tool execution, capability manifests scope which binaries and paths are reachable per invocation; does not address postinstall scripts that invoke standalone AI CLIs outside MCP.
+
+## Technical Implementation
+
+### Prerequisites
+- Linux kernel 5.13+ (Landlock LSM enabled; verify with `CONFIG_SECURITY_LANDLOCK=y`)
+- seccomp support (standard in all major Linux distributions since kernel 3.17)
+- Sigstore toolchain for attestation (cosign or equivalent)
+
+### Capability Manifest
+Each MCP server declares a capability manifest specifying the per-invocation constraints for each tool:
+
+```yaml
+tools:
+  read_file:
+    filesystem:
+      allow_read:
+        - /data/inputs
+    network: none
+    syscalls: default_read_only
+
+  execute_query:
+    filesystem:
+      allow_read:
+        - /etc/db.conf
+    network:
+      allow_connect:
+        - 10.0.0.5:5432
+    syscalls: default_network
+```
+
+### Enforcement Flow
+```
+MCP Host
+    |
+    v
+nono broker (embeddable library)
+    |  -- reads tool capability manifest
+    |  -- applies Landlock ruleset for this invocation
+    |  -- applies seccomp filter for this invocation
+    |  -- issues phantom token (scoped, short-lived)
+    |  -- emits Sigstore attestation record
+    |
+    v
+Tool execution (capability-bounded)
+    |
+    v
+nono broker
+    |  -- revokes phantom token
+    |  -- tears down Landlock + seccomp context
+    |  -- finalizes attestation record
+    v
+MCP Host (returns result)
+```
+
+### Integration Examples
+
+```rust
+use nono::{Broker, CapabilityManifest};
+
+let manifest = CapabilityManifest::from_file("nono.yaml")?;
+let broker = Broker::new(manifest);
+
+broker.execute("read_file", |ctx| {
+    tool_impl(ctx)
+})?;
+```
+
+```python
+from nono import Broker
+
+broker = Broker.from_manifest("nono.yaml")
+
+with broker.invocation("read_file") as ctx:
+    result = tool_impl(ctx.token)
+```
+
+```typescript
+import { Broker } from '@nolabs/nono';
+
+const broker = await Broker.fromManifest('nono.yaml');
+
+const result = await broker.invoke('read_file', async (ctx) => {
+  return toolImpl(ctx.token);
+});
+```
+
+### Monitoring
+Violations of the per-invocation capability manifest produce kernel-level audit events. Monitor for:
+- `LANDLOCK_ACCESS_FS_*` denial events against paths outside the declared manifest
+- seccomp `SECCOMP_RET_KILL` or `SECCOMP_RET_ERRNO` events for filtered syscalls
+- Phantom token usage outside the declared invocation window
+- Sigstore attestation gaps indicating broker bypass
+
+## References
+- [Linux Landlock LSM documentation](https://docs.kernel.org/userspace-api/landlock.html)
+- [seccomp filter documentation](https://www.kernel.org/doc/html/latest/userspace-api/seccomp_filter.html)
+- [Sigstore project](https://www.sigstore.dev/)
+- [nono reference implementation](https://nono.sh)
+- [Kubefence (Red Hat NRI plugin)](https://github.com/redhat-nfvpe/kubefence)
+- [AgentBound formal reference (arXiv:2510.21236)](https://arxiv.org/abs/2510.21236)
+
+## Related Mitigations
+- [SAF-M-9](../SAF-M-9/README.md): Sandboxed Testing — isolates test execution from production at the environment level; complementary to per-call capability enforcement in running production servers
+
+## Version History
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| 1.0 | 2026-06-15 | Initial documentation | SAF-MCP Contributors |

--- a/techniques/SAF-T1101/README.md
+++ b/techniques/SAF-T1101/README.md
@@ -602,6 +602,8 @@ class SecureMCPServer:
 2. **Environment Variables**: Set minimal, explicit environment variables for subprocesses
 3. **Resource Limits**: Implement CPU, memory, and file descriptor limits
 4. **Syscall Filtering**: Use seccomp-bpf to restrict available system calls
+<!-- SAF-M-74 added via PR [branch: add-saf-m-74-per-invocation-capability-brokering]; this section's other items lack SAF-M cross-links as of this PR -->
+5. **[SAF-M-74: Per-Invocation Capability Brokering](../../mitigations/SAF-M-74/README.md)**: Confine successful command injection to per-call syscall, filesystem, and binary allowlists rather than preventing injection itself.
 
 ### Detective Controls
 

--- a/techniques/SAF-T1111/README.md
+++ b/techniques/SAF-T1111/README.md
@@ -287,6 +287,7 @@ tags:
 3. **[SAF-M-6: Sandboxing](../../mitigations/SAF-M-6/README.md)**: Isolate package installation processes in sandboxed environments
 4. **[SAF-M-8: Network Security](../../mitigations/SAF-M-8/README.md)**: Monitor and restrict network access during package installations
 5. **[SAF-M-12: Audit Logging](../../mitigations/SAF-M-12/README.md)**: Comprehensive logging of AI tool invocations and system commands
+6. **[SAF-M-74: Per-Invocation Capability Brokering](../../mitigations/SAF-M-74/README.md)**: When weaponization flows through MCP tool execution, constrain each call to declared binaries and filesystem scope via per-invocation capability manifests (does not address postinstall scripts that invoke standalone AI CLIs outside MCP).
 
 ### AI Tool Hardening
 - **Disable Dangerous Flags**: Configure AI CLI tools to reject dangerous permission-bypassing flags

--- a/techniques/SAF-T1302/README.md
+++ b/techniques/SAF-T1302/README.md
@@ -127,6 +127,7 @@ fields:
 3.  **[SAF-M-5: Content Sanitization](../../mitigations/SAF-M-5/README.md)**: Strictly validate and allowlist arguments. Reject shell metacharacters.
 4.  **[SAF-M-9: Sandboxed Testing](../../mitigations/SAF-M-9/README.md)**: Use container security contexts (`runAsNonRoot: true`, `allowPrivilegeEscalation: false`) to enforce isolation at the OS level.
 5.  **Filesystem Isolation**: Use `chroot` (Linux) or similar jail mechanisms to restrict the tool's file access to a specific directory tree, preventing access to the real root filesystem even if the process has elevated privileges within that scope.
+6.  **[SAF-M-74: Per-Invocation Capability Brokering](../../mitigations/SAF-M-74/README.md)**: Enforce per-call Landlock and seccomp ceilings so privileged tools cannot reach paths or syscalls outside their declared manifest even when an agent is tricked into invoking them.
 
 ### Detective Controls
 1.  **[SAF-M-12: Audit Logging](../../mitigations/SAF-M-12/README.md)**: Log the Effective User ID (EUID) of the process executing the tool.

--- a/techniques/SAF-T1303/README.md
+++ b/techniques/SAF-T1303/README.md
@@ -83,6 +83,7 @@ Important: The standalone Sigma rule for this technique is provided in `detectio
 1. **SAF-M-9: Sandboxed Testing**: Run new/updated MCP tools/servers in tightly isolated environments; disable privileged modes and restrict host mounts during evaluation.
 2. **SAF-M-6: Tool Registry Verification**: Enforce provenance and review for tools/servers that can invoke container runtimes; verify configuration and runtime versions.
 3. **SAF-M-14: Server Allowlisting**: Limit which MCP servers may be attached or invoked, reducing exposure to malicious orchestrators.
+4. **SAF-M-74: Per-Invocation Capability Brokering**: Limit filesystem and syscall reach after a container boundary violation by applying per-invocation Landlock and seccomp profiles (does not substitute for patching vulnerable runtimes).
 
 ### Detective Controls
 1. **SAF-M-12: Audit Logging**: Log runtime invocations, including working directory and mount details, to support detection and forensics.

--- a/techniques/SAF-T1304/README.md
+++ b/techniques/SAF-T1304/README.md
@@ -177,6 +177,7 @@ tags:
 5. **Token Scope Validation**: Implement strict scope validation to prevent tokens from being used outside their intended purpose ([OAuth 2.0 Security Best Practices](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics))
 6. **Proof of Possession (PoP) Tokens**: Use PoP tokens that bind authentication to specific clients and prevent relay attacks ([RFC 7800](https://tools.ietf.org/html/rfc7800))
 7. **Short Token Lifetimes**: Implement short-lived tokens with frequent rotation to limit the window for relay attacks ([OAuth 2.1 Security](https://datatracker.ietf.org/doc/draft-ietf-oauth-v2-1/))
+8. **[SAF-M-74: Per-Invocation Capability Brokering](../../mitigations/SAF-M-74/README.md)**: Issue phantom tokens scoped to a single tool invocation so stolen credentials cannot be relayed to higher-privilege tools outside the invocation window.
 
 ### Detective Controls
 1. **[SAF-M-10: Automated Scanning](../../mitigations/SAF-M-10/README.md)**: Regularly scan for unusual token usage patterns and cross-tool authentication


### PR DESCRIPTION
# Add SAF-M-74: Per-Invocation Capability Brokering

## Summary

MCP servers get a static set of OS permissions at startup. Every tool call runs with the same ambient authority, whether it needs it or not. SAF-T1302 is the direct result of this gap.

SAF-M-74 enforces a per-call capability manifest at kernel level using Linux Landlock LSM and seccomp. Each tool call gets exactly the filesystem paths, network destinations, and syscalls it declared, nothing else. Credentials use a phantom token model: short-lived, single-use, scoped to the invocation. Every call gets a Sigstore attestation record.

Cross-references added to five technique files: SAF-T1302, SAF-T1303, SAF-T1304, SAF-T1101, SAF-T1111. One new row in MITIGATIONS.md, stats updated.

## What this doesn't do

SAF-M-74 doesn't prevent the SAF-T1303 sandbox escape or the SAF-T1101 command injection. It limits what happens after either one succeeds, it doesn't patch the underlying vulnerability. The technique cross-references are worded to match.

## Files changed

- `mitigations/SAF-M-74/README.md` (new). Structure matches SAF-M-9, the only other entry in this category.
- `MITIGATIONS.md`. One row added. Total Mitigations 47 to 48, High Effectiveness 26 to 27, Isolation and Containment 1 to 2.
- `techniques/SAF-T1302`, `SAF-T1304`, `SAF-T1101`, `SAF-T1111`. SAF-M-74 added to each file's existing list, matching that file's link format.
- `techniques/SAF-T1303`. Same addition, matching that file's existing unlinked-prose format (used by its SAF-M-9, SAF-M-6, SAF-M-14 entries too).

## Two minor things unrelated to this PR I found and didn't touch: 

`techniques/SAF-T1101/README.md` had no SAF-M cross-links anywhere before this PR. Added one for SAF-M-74 with an inline comment flagging the gap. Didn't backfill the rest.

`MITIGATIONS.md`'s category distribution sums to 49 against a stated total of 48. Pre-existing, not introduced here. Likely a label mismatch ("Supply Chain Control" vs. "Supply Chain Security"). Flagging it, not fixing it here.

## Reference implementations

nono ([[nono.sh](https://nono.sh/)](https://nono.sh)): Rust, embeddable broker library. Landlock, seccomp, Sigstore, phantom tokens.

Kubefence: Red Hat NRI plugin, same model, in production on Red Hat OpenShift.

AgentBound: academic reference, [[arXiv:2510.21236](https://arxiv.org/abs/2510.21236)](https://arxiv.org/abs/2510.21236).

## Checklist

- [x] Mitigation ID verified against live directory (SAF-M-73 was highest existing)
- [x] Category confirmed: Isolation and Containment
- [x] All five technique IDs and titles verified against their actual files
- [x] Claims scoped to what the control does, not more
- [x] Structure matches SAF-M-9
- [x] Cross-references added in all five technique files, matching each file's format
- [x] MITIGATIONS.md stats updated and consistent
- [x] All internal links resolve
- [x] Licensed under Community Specification License 1.0