### PR TITLE
Add detections/ registry for stable cross-project rule-ID linkage

### DIFF
--- a/detections/README.md
+++ b/detections/README.md
@@ -1,0 +1,67 @@
+# External Detection Coverage Registry
+
+This directory maps SAF techniques to detection rules maintained by upstream
+projects, as proposed in issue #207. It parallels the technique registry
+pattern: one YAML file per SAF-T ID that has external detection coverage.
+
+## Ownership boundary
+
+SAFE-MCP records the pointer. Upstream projects own rule correctness.
+
+- Each entry carries a GitHub handle as `maintainer` (maintainer-of-record),
+  so stale entries have an owner to bump or remove.
+- Entries are community-contributed and do not block taxonomy releases.
+- This registry is distinct from `techniques/SAF-T*/detection-rule.yml`,
+  which are SAFE-MCP-owned example rules living with each technique.
+
+## File format
+
+One file per technique, named `<SAF-T-ID>.yaml`:
+
+```yaml
+safe_t_id: SAF-T1105
+detections:
+  - project: atr
+    rule_id: ATR-2026-00569
+    version: ">=3.1.0"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: One-line description of what the upstream rule detects.
+```
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `project` | yes | Upstream project slug (lowercase). Known slugs and their rule-ID formats are listed in `validate.py`. |
+| `rule_id` | yes | Stable rule identifier in the upstream project's namespace. |
+| `version` | yes | Semver range of upstream releases that contain the rule (e.g. `">=3.1.0"`). |
+| `maintainer` | yes | GitHub handle of the maintainer-of-record for this entry. |
+| `last_validated` | yes | ISO date (YYYY-MM-DD) the mapping was last checked against both the technique description and the upstream rule content. |
+| `notes` | no | Short factual description of what the upstream rule detects, so reviewers can check the mapping without leaving the file. |
+
+## Mapping quality bar
+
+An entry means: the referenced upstream rule detects the attack described by
+the technique — verified by reading both the technique description and the
+rule's detection logic, not by keyword match. When adding entries, cite what
+the rule actually matches in `notes`.
+
+## Validation
+
+```bash
+python3 detections/validate.py            # schema, ID formats, semver ranges, technique dirs
+python3 detections/validate.py --online   # additionally resolve rule IDs against upstream repos
+```
+
+Requires Python 3.9+ and PyYAML (`pip install pyyaml`). The script exits
+non-zero on any failure, so it can run in CI on every PR touching this
+directory.
+
+## Adding or updating entries
+
+1. Add or edit `detections/<SAF-T-ID>.yaml` following the format above.
+2. Run `python3 detections/validate.py`.
+3. Open a PR. If you are updating an entry you do not maintain, tag the
+   entry's maintainer-of-record.
+
+Stale or broken entries (rule removed upstream, project archived) should be
+removed by — or after pinging — the maintainer-of-record.

--- a/detections/SAF-T1001.yaml
+++ b/detections/SAF-T1001.yaml
@@ -1,0 +1,21 @@
+# SAF-T1001: Tool Poisoning Attack (TPA)
+safe_t_id: SAF-T1001
+detections:
+  - project: atr
+    rule_id: ATR-2026-00103
+    version: ">=1.0.1"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects explicit LLM-directed safety-bypass directives embedded in tool
+      descriptions ("NOTE TO AI: disregard/ignore/bypass ... safety/security/
+      previous instructions").
+  - project: atr
+    rule_id: ATR-2026-00105
+    version: ">=1.0.1"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects concealment directives in tool descriptions instructing the
+      model to hide actions from the user ("do not mention/tell/inform the
+      user"), the tell of a tool performing hidden operations.

--- a/detections/SAF-T1008.yaml
+++ b/detections/SAF-T1008.yaml
@@ -1,0 +1,14 @@
+# SAF-T1008: Tool Shadowing Attack
+safe_t_id: SAF-T1008
+detections:
+  - project: atr
+    rule_id: ATR-2026-01301
+    version: ">=3.4.0"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects tool descriptions that hijack the agent's tool selection or
+      shadow legitimate tools: exclusive-use directives ("use this tool no
+      matter ...", "do NOT use other tools"), conditional hijacks ("when user
+      wants X, use this tool instead"), and post-hoc result-override hooks
+      ("after using <tool>, run this to modify its result").

--- a/detections/SAF-T1101.yaml
+++ b/detections/SAF-T1101.yaml
@@ -1,0 +1,32 @@
+# SAF-T1101: Command Injection
+safe_t_id: SAF-T1101
+detections:
+  - project: atr
+    rule_id: ATR-2026-00296
+    version: ">=2.0.10"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects shell command-injection payload shapes reaching agent/MCP
+      execution surfaces: $() substitution against sensitive paths, backtick
+      execution, Perl/Ruby system-call interpolation (sourced from NVIDIA
+      garak shell-access payloads).
+  - project: atr
+    rule_id: ATR-2026-00521
+    version: ">=2.2.0"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects benign-looking agent task requests carrying chained shell
+      commands (";"/"&&" into curl/wget/nc/bash) that exfiltrate env vars,
+      .env files, or credentials to attacker-controlled URLs.
+  - project: atr
+    rule_id: ATR-2026-01980
+    version: ">=3.5.5"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects GHSA-vcv2-r9jh-99m5: quote-breakout OS command injection via
+      MCP tool parameters interpolated into execSync() shell strings
+      (agentic-flow <= 2.0.13) — a concrete instance of unsanitized MCP tool
+      input reaching a system shell.

--- a/detections/SAF-T1102.yaml
+++ b/detections/SAF-T1102.yaml
@@ -1,0 +1,22 @@
+# SAF-T1102: Prompt Injection (Multiple Vectors)
+safe_t_id: SAF-T1102
+detections:
+  - project: atr
+    rule_id: ATR-2026-00004
+    version: ">=1.0.1"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects system-prompt override attempts arriving through injection
+      channels: replacement-prompt statements, ChatML/Llama/Mistral special
+      tokens, JSON role injection, and YAML-style "system:" directives.
+  - project: atr
+    rule_id: ATR-2026-00400
+    version: ">=2.0.11"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects instruction-redirect keywords buried inside otherwise-legitimate
+      data ("Ignore the above directions and ...", "Disregard all info except
+      ..."), including the tool-output channel — the latent/indirect injection
+      classes from NVIDIA garak.

--- a/detections/SAF-T1105.yaml
+++ b/detections/SAF-T1105.yaml
@@ -1,0 +1,13 @@
+# SAF-T1105: Path Traversal via File Tool
+safe_t_id: SAF-T1105
+detections:
+  - project: atr
+    rule_id: ATR-2026-00569
+    version: ">=3.1.0"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects file-tool path arguments escaping their intended directory
+      scope: deep ../ chains reaching sensitive targets (/etc/passwd, .ssh,
+      system32) and URL-/double-encoded traversal sequences (%2e%2e, %252e,
+      %c0%af).

--- a/detections/SAF-T1501.yaml
+++ b/detections/SAF-T1501.yaml
@@ -1,0 +1,14 @@
+# SAF-T1501: Full-Schema Poisoning (FSP)
+safe_t_id: SAF-T1501
+detections:
+  - project: atr
+    rule_id: ATR-2026-02025
+    version: ">=3.5.7"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects FSP directive placements in non-description inputSchema fields:
+      imperative parameter names (content_from_reading_ssh_id_rsa), injected
+      extra/sidenote/instructions fields carrying read-and-exfiltrate
+      directives, and poisoned required/default values ("in order to ... you
+      must ... the content of ~/.ssh/id_rsa").

--- a/detections/SAF-T1503.yaml
+++ b/detections/SAF-T1503.yaml
@@ -1,0 +1,22 @@
+# SAF-T1503: Env-Var Scraping
+safe_t_id: SAF-T1503
+detections:
+  - project: atr
+    rule_id: ATR-2026-00583
+    version: ">=3.4.0"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects read/fs tool invocations whose path argument targets .env,
+      .env.*, secrets.*, credentials, .npmrc or .netrc — in function-call form
+      (read_file(".env")) and structured JSON tool-input form
+      ({"path": ".env"}).
+  - project: atr
+    rule_id: ATR-2026-00115
+    version: ">=1.0.1"
+    maintainer: eeee2345
+    last_validated: 2026-07-10
+    notes: >-
+      Detects bulk environment harvesting (printenv, bare env, whole
+      process.env/os.environ access), .env file reads, and dotenv loading
+      combined with network calls indicating exfiltration.

--- a/detections/validate.py
+++ b/detections/validate.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Validate detections/ registry files.
+
+Checks (offline, default):
+  - filename is <SAF-T-ID>.yaml and matches the safe_t_id field
+  - techniques/<SAF-T-ID>/ exists in this repository
+  - every entry has project / rule_id / version / maintainer / last_validated
+  - rule_id matches the known format for the project (when known)
+  - version is a valid semver range (space-separated comparators)
+  - maintainer looks like a GitHub handle
+  - last_validated is an ISO date (YYYY-MM-DD)
+
+With --online, additionally resolves each rule_id against the upstream
+repository to confirm the referenced rule file exists.
+
+Usage:
+  python3 detections/validate.py [--online]
+
+Requires Python 3.9+ and PyYAML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+DETECTIONS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = DETECTIONS_DIR.parent
+
+FILENAME_RE = re.compile(r"^SAF-T\d{4}\.yaml$")
+SEMVER_COMPARATOR_RE = re.compile(r"^(>=|<=|>|<|=|~|\^)?\d+\.\d+\.\d+$")
+GITHUB_HANDLE_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+
+REQUIRED_FIELDS = ("project", "rule_id", "version", "maintainer", "last_validated")
+OPTIONAL_FIELDS = ("notes",)
+
+# Known upstream projects: rule-ID format and an online resolver.
+# The resolver returns the set of rule IDs present in the upstream repo.
+KNOWN_PROJECTS = {
+    "atr": {
+        "rule_id_re": re.compile(r"^ATR-\d{4}-\d{4,5}$"),
+        "tree_url": (
+            "https://api.github.com/repos/Agent-Threat-Rule/"
+            "agent-threat-rules/git/trees/main?recursive=1"
+        ),
+        "rule_path_re": re.compile(r"^rules/.+/(ATR-\d{4}-\d{4,5})-.+\.yaml$"),
+    },
+}
+
+
+def check_entry(entry: object, source: str) -> list[str]:
+    """Validate one detection entry; returns a list of error strings."""
+    if not isinstance(entry, dict):
+        return [f"{source}: entry is not a mapping"]
+
+    errors = []
+    unknown = set(entry) - set(REQUIRED_FIELDS) - set(OPTIONAL_FIELDS)
+    if unknown:
+        errors.append(f"{source}: unknown field(s): {', '.join(sorted(unknown))}")
+
+    missing = [f for f in REQUIRED_FIELDS if f not in entry]
+    if missing:
+        errors.append(f"{source}: missing field(s): {', '.join(missing)}")
+        return errors
+
+    project = entry["project"]
+    if not isinstance(project, str) or not re.match(r"^[a-z0-9][a-z0-9-]{0,40}$", project):
+        errors.append(f"{source}: project must be a lowercase slug, got {project!r}")
+
+    rule_id = entry["rule_id"]
+    if not isinstance(rule_id, str) or not rule_id:
+        errors.append(f"{source}: rule_id must be a non-empty string")
+    elif isinstance(project, str) and project in KNOWN_PROJECTS:
+        pattern = KNOWN_PROJECTS[project]["rule_id_re"]
+        if not pattern.match(rule_id):
+            errors.append(
+                f"{source}: rule_id {rule_id!r} does not match the "
+                f"{project} format {pattern.pattern}"
+            )
+
+    version = entry["version"]
+    if not isinstance(version, str) or not version.strip():
+        errors.append(f"{source}: version must be a non-empty semver range string")
+    else:
+        bad = [t for t in version.split() if not SEMVER_COMPARATOR_RE.match(t)]
+        if bad:
+            errors.append(
+                f"{source}: invalid semver comparator(s) {bad} in version {version!r} "
+                '(expected e.g. ">=3.1.0" or ">=3.1.0 <4.0.0")'
+            )
+
+    maintainer = entry["maintainer"]
+    if not isinstance(maintainer, str) or not GITHUB_HANDLE_RE.match(maintainer):
+        errors.append(f"{source}: maintainer must be a GitHub handle, got {maintainer!r}")
+
+    last_validated = entry["last_validated"]
+    date_str = (
+        last_validated.isoformat()
+        if isinstance(last_validated, datetime.date)
+        else last_validated
+    )
+    try:
+        datetime.date.fromisoformat(str(date_str))
+    except ValueError:
+        errors.append(f"{source}: last_validated must be YYYY-MM-DD, got {last_validated!r}")
+
+    notes = entry.get("notes")
+    if notes is not None and not isinstance(notes, str):
+        errors.append(f"{source}: notes must be a string")
+
+    return errors
+
+
+def check_file(path: Path) -> tuple[list[str], list[dict]]:
+    """Validate one registry file; returns (errors, entries)."""
+    if not FILENAME_RE.match(path.name):
+        return ([f"{path.name}: filename must be <SAF-T-ID>.yaml"], [])
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return ([f"{path.name}: YAML parse error: {exc}"], [])
+
+    if not isinstance(data, dict):
+        return ([f"{path.name}: top level must be a mapping"], [])
+
+    errors = []
+    expected_id = path.stem
+    if data.get("safe_t_id") != expected_id:
+        errors.append(
+            f"{path.name}: safe_t_id {data.get('safe_t_id')!r} does not match "
+            f"filename (expected {expected_id!r})"
+        )
+
+    technique_dir = REPO_ROOT / "techniques" / expected_id
+    if not technique_dir.is_dir():
+        errors.append(f"{path.name}: no technique directory at techniques/{expected_id}/")
+
+    unknown_top = set(data) - {"safe_t_id", "detections"}
+    if unknown_top:
+        errors.append(f"{path.name}: unknown top-level field(s): {', '.join(sorted(unknown_top))}")
+
+    entries = data.get("detections")
+    if not isinstance(entries, list) or not entries:
+        errors.append(f"{path.name}: detections must be a non-empty list")
+        return (errors, [])
+
+    for i, entry in enumerate(entries):
+        errors.extend(check_entry(entry, f"{path.name}: detections[{i}]"))
+
+    return (errors, [e for e in entries if isinstance(e, dict)])
+
+
+def fetch_upstream_rule_ids(project: str) -> set[str] | None:
+    """Fetch the set of rule IDs published by a known upstream project."""
+    config = KNOWN_PROJECTS.get(project)
+    if config is None:
+        return None
+    request = urllib.request.Request(
+        config["tree_url"], headers={"Accept": "application/vnd.github+json"}
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        tree = json.load(response).get("tree", [])
+    matches = (config["rule_path_re"].match(node.get("path", "")) for node in tree)
+    return {m.group(1) for m in matches if m}
+
+
+def check_online(entries: list[dict]) -> list[str]:
+    """Resolve rule IDs against upstream repos; returns error strings."""
+    errors = []
+    projects = {e["project"] for e in entries if e.get("project") in KNOWN_PROJECTS}
+    for project in sorted(projects):
+        try:
+            upstream_ids = fetch_upstream_rule_ids(project)
+        except OSError as exc:
+            errors.append(f"online: could not fetch {project} rule index: {exc}")
+            continue
+        for entry in entries:
+            if entry.get("project") == project and entry["rule_id"] not in upstream_ids:
+                errors.append(
+                    f"online: {entry['rule_id']} not found in upstream {project} repository"
+                )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--online",
+        action="store_true",
+        help="also resolve rule IDs against upstream repositories",
+    )
+    args = parser.parse_args()
+
+    files = sorted(p for p in DETECTIONS_DIR.glob("*.yaml"))
+    if not files:
+        print("no registry files found in detections/")
+        return 1
+
+    all_errors = []
+    all_entries = []
+    for path in files:
+        errors, entries = check_file(path)
+        all_errors.extend(errors)
+        all_entries.extend(entries)
+
+    if args.online and not all_errors:
+        all_errors.extend(check_online(all_entries))
+
+    if all_errors:
+        for error in all_errors:
+            print(f"FAIL {error}")
+        print(f"\n{len(all_errors)} error(s) across {len(files)} file(s)")
+        return 1
+
+    print(f"OK {len(files)} file(s), {len(all_entries)} detection entr(y/ies) valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements the detections/ registry proposed in #207: a new top-level directory mapping SAF techniques to detection rules maintained by upstream projects, one YAML file per SAF-T ID. SAFE-MCP records the pointer; upstream projects own rule correctness. Each entry carries a GitHub handle as maintainer-of-record, a semver range of upstream releases containing the rule, and a last-validated date.

Initial batch: 7 techniques, 12 entries (SAF-T1001, SAF-T1008, SAF-T1101, SAF-T1102, SAF-T1105, SAF-T1501, SAF-T1503). Every mapping was verified by reading both the technique description and the upstream rule's detection logic, not by keyword match; the notes field on each entry records what the rule actually matches so reviewers can check the mapping without leaving the file.

Also includes detections/validate.py (Apache 2.0, Python 3.9+, PyYAML): validates filename/ID consistency, technique directory existence, per-project rule-ID formats, semver ranges, maintainer handles, and dates. With --online it additionally resolves every rule ID against the upstream repository. Exits non-zero on any failure, so it can run in CI on every PR touching detections/. Happy to add a workflow file for that in this PR or a follow-up, whichever the maintainers prefer.

Registry entries follow the shape discussed in #207 and the boundary it proposes: entries are community-contributed pointers, do not touch technique content, and do not block taxonomy releases. Stale entries have an owner to bump or remove. The registry is project-neutral; other projects (Sigma, etc.) can add entries under the same schema.

Conflict-of-interest disclosure: I maintain ATR, the upstream project referenced by all initial entries, and I am the maintainer-of-record on each of them, so staleness pings land on me.

## Type of Contribution

- [ ] New Technique
- [ ] New Mitigation
- [ ] Update to existing content
- [x] Documentation improvement

## Checklist

- [x] DCO sign-off included in commits (`git commit -s`)
- [ ] For technique contributions: see [TEMPLATE-CHECKLIST.md](techniques/TEMPLATE-CHECKLIST.md)
- [ ] For mitigation contributions: see [TEMPLATE-CHECKLIST.md](mitigations/TEMPLATE-CHECKLIST.md)

## Related Issues

Closes #207
