### PR TITLE
Add Community Specification governance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,112 +1,92 @@
-## CNCF Community Code of Conduct v1.3
+# Contributor Covenant Code of Conduct
 
-Other languages available:
-- [Arabic/العربية](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/ar.md)
-- [Bengali/বাংলা](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/bn.md)
-- [Bulgarian/Български](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/bg.md)
-- [Chinese/中文](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/zh.md)
-- [Czech/Česky](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/cs.md)
-- [Farsi/فارسی](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/fa.md)
-- [French/Français](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/fr.md)
-- [German/Deutsch](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/de.md)
-- [Hebrew/עברית](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/he.md)
-- [Hindi/हिन्दी](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/hi.md)
-- [Hungarian/Magyar](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/hu.md)
-- [Indonesian/Bahasa Indonesia](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/id.md)
-- [Italian/Italiano](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/it.md)
-- [Japanese/日本語](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/ja.md)
-- [Korean/한국어](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/ko.md)
-- [Polish/Polski](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/pl.md)
-- [Portuguese/Português](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/pt.md)
-- [Russian/Русский](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/ru.md)
-- [Spanish/Español](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/es.md)
-- [Turkish/Türkçe](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/tr.md)
-- [Ukrainian/Українська](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/uk.md)
-- [Vietnamese/Tiếng Việt](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/vi.md)
+> This Code of Conduct applies to the entire SAF-MCP repository and to all
+> community spaces of the Secure Agentic Framework project, not only to the
+> mitigations Working Group. It is the Code of Conduct distributed with the
+> [Community Specification 1.0](https://github.com/CommunitySpecification/1.0)
+> process. Reporting contacts are listed in
+> [mitigations/NOTICES.md](mitigations/NOTICES.md); see also
+> [GOVERNANCE.md](GOVERNANCE.md).
 
-### Community Code of Conduct
+## Our Pledge
 
-As contributors, maintainers, and participants in the CNCF community, and in the interest of fostering
-an open and welcoming community, we pledge to respect all people who participate or contribute
-through reporting issues, posting feature requests, updating documentation,
-submitting pull requests or patches, attending conferences or events, or engaging in other community or project activities.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
-We are committed to making participation in the CNCF community a harassment-free experience for everyone, regardless of age, body size, caste, disability, ethnicity, level of experience, family status, gender, gender identity and expression, marital status, military or veteran status, nationality, personal appearance, race, religion, sexual orientation, socioeconomic status, tribe, or any other dimension of diversity.
-
-## Scope
-
-This code of conduct applies:
-* within project and community spaces,
-* in other spaces when an individual CNCF community participant's words or actions are directed at or are about a CNCF project, the CNCF community, or another CNCF community participant in the context of a CNCF activity.
-
-### CNCF Events
-
-CNCF events that are produced by the Linux Foundation with professional events staff are governed by the Linux Foundation [Events Code of Conduct](https://events.linuxfoundation.org/code-of-conduct/) available on the event page. This is designed to be used in conjunction with the CNCF Code of Conduct.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-The CNCF Community is open, inclusive and respectful. Every member of our community has the right to have their identity respected.
-
-Examples of behavior that contributes to a positive environment include but are not limited to:
+Examples of behavior that contributes to a positive environment for our community include:
 
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
-* Using welcoming and inclusive language
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
 
+Examples of unacceptable behavior include:
 
-Examples of unacceptable behavior include but are not limited to:
-
-* The use of sexualized language or imagery
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment in any form
+* Public or private harassment
 * Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Violence, threatening violence, or encouraging others to engage in violent behavior
-* Stalking or following someone without their consent
-* Unwelcome physical contact
-* Unwelcome sexual or romantic attention or advances
-* Using CNCF projects or community spaces for political campaigning or promotion of political causes 
-  that are unrelated to the advancement of cloud native technology. To clarify, this policy does not restrict individuals' personal attire, including attire that expresses personal beliefs or aspects of identity.
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-The following behaviors are also prohibited:
-* Providing knowingly false or misleading information in connection with a Code of Conduct investigation or otherwise intentionally tampering with an investigation.
-* Retaliating against a person because they reported an incident or provided information about an incident as a witness.
+## Enforcement Responsibilities
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
-By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect
-of managing a CNCF project.
-Project maintainers who do not follow or enforce the Code of Conduct may be temporarily or permanently removed from the project team.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-## Reporting
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
-For incidents occurring in the Kubernetes community, contact the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>. You can expect a response within three business days.
+## Scope
 
-For other projects, or for incidents that are project-agnostic or impact multiple CNCF projects, please contact the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) via <conduct@cncf.io>.  Alternatively, you can contact any of the individual members of the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) to submit your report. For more detailed instructions on how to submit a report, including how to submit a report anonymously, please see our [Incident Resolution Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md). You can expect a response within three business days.
-
-For incidents occurring at CNCF event that is produced by the Linux Foundation, please contact <eventconduct@cncf.io>.
-
-## Frequently asked questions
-For more information about this Code of Conduct, please see the [CNCF Code of Conduct Frequently Asked Questions](https://www.cncf.io/conduct/faq/).
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Upon review and investigation of a reported incident, the CoC response team that has jurisdiction will determine what action is appropriate based on this Code of Conduct and its related documentation.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement as set forth in the repository's [mitigations/NOTICES.md](mitigations/NOTICES.md) file. All complaints will be reviewed and investigated promptly and fairly.
 
-For information about which Code of Conduct incidents are handled by project leadership, which incidents are handled by the CNCF Code of Conduct Committee, and which incidents are handled by the Linux Foundation (including its events team), see our [Jurisdiction Policy](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md).
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
-## Amendments
+## Enforcement Guidelines
 
-Consistent with the CNCF Charter, any substantive changes to this Code of Conduct must be approved by the Technical Oversight Committee.
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
-## Acknowledgements
+### 1. Correction
 
-This Code of Conduct is adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 2.0 available at
-http://contributor-covenant.org/version/2/0/code_of_conduct/
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the project community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome to the SAF-MCP project! We appreciate your interest in contributing to t
 
 ## Code of Conduct
 
-This project follows the [CNCF Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms. Please read the full text to understand what actions will and will not be tolerated.
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms. Please read the full text to understand what actions will and will not be tolerated. Reporting contacts are listed in [mitigations/NOTICES.md](mitigations/NOTICES.md).
 
 ## Licensing
 
@@ -15,6 +15,10 @@ This project uses a multi-license structure:
 - **Code** (including scripts, detection rules, and software) is licensed under [Apache 2.0](LICENSE-APACHE-2.0)
 
 By contributing, you agree that your contributions will be licensed under the applicable license based on the type and location of the content. In particular, by contributing to the mitigations you agree to the terms of the Community Specification License 1.0.
+
+## Governance
+
+The mitigations specification (`mitigations/` and `MITIGATIONS.md`) is developed as a Community Specification Working Group, governed by [GOVERNANCE.md](GOVERNANCE.md). That document defines the Maintainer, Editor, and Participant roles, the consensus-based decision making and appeal process, and the Pre-Draft → Draft → Approved specification lifecycle. The Working Group's scope is defined in [mitigations/SCOPE.md](mitigations/SCOPE.md), and license acceptance, withdrawals, and patent exclusions are recorded in [mitigations/NOTICES.md](mitigations/NOTICES.md).
 
 ## Developer Certificate of Origin (DCO)
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,62 @@
+# Community Specification Governance Policy 1.0
+
+This document provides the governance policy for specifications and other documents developed using the Community Specification process in a repository (each a “Working Group”). Each Working Group Participant must adhere to the requirements in this document.  Each Working Group is part of the Secure Agentic Framework project, which has been established as Secure Agentic Framework a Series of LF Projects, LLC.  The policies of LF Projects, LLC, available at www.lfprojects.org/policies/ apply to participation in each Working Group.
+
+> **Working Groups in this repository.** The Working Group in this repository is
+> the SAF-MCP Mitigations specification (`mitigations/` and `MITIGATIONS.md`),
+> whose scope is defined in [mitigations/SCOPE.md](mitigations/SCOPE.md) and whose
+> notices are recorded in [mitigations/NOTICES.md](mitigations/NOTICES.md).
+> Material outside that Scope — including the techniques documentation
+> (`techniques/`) and all code — is not developed under the Community
+> Specification process and is licensed as described in [LICENSE](LICENSE).
+> Contribution mechanics for the whole repository, including Developer
+> Certificate of Origin sign-off, are described in
+> [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## 1.	Roles.
+
+Each Working Group may include the following roles. Additional roles may be adopted and documented by the Working Group.
+
+**1.1.	Maintainer.** “Maintainers” are responsible for organizing activities around developing, maintaining, and updating the specification(s) developed by the Working Group.  Maintainers are also responsible for determining consensus and coordinating appeals.  Each Working Group will designate one or more Maintainer for that Working Group.  A Working Group may select a new or additional Maintainer(s) upon Approval of the Working Group Participants.
+
+**1.2.	Editor.**  “Editors” are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. Each Working Group will designate an Editor for that Working Group.  A Working Group may select a new Editor upon Approval of the Working Group Participants.
+
+**1.3.	Participants.**  “Participants” are those that have made Contributions to the Working Group subject to the Community Specification License.
+
+## 2.	Decision Making.
+
+**2.1.	Consensus-Based Decision Making.**  Working Groups make decisions through a consensus process (“Approval” or “Approved”).  While the agreement of all Participants is preferred, it is not required for consensus.  Rather, the Maintainer will determine consensus based on their good faith consideration of a number of factors, including the dominant view of the Working Group Participants and nature of support and objections.  The Maintainer will document evidence of consensus in accordance with these requirements.
+
+**2.2.	Appeal Process.**  Decisions may be appealed be via a pull request or an issue, and that appeal will be considered by the Maintainer in good faith, who will respond in writing within a reasonable time.
+
+## 3.	Ways of Working.
+
+Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi.org/Shared%20Documents/Standards%20Activities/American%20National%20Standards/Procedures,%20Guides,%20and%20Forms/2020_ANSI_Essential_Requirements.pdf), Community Specification Working Groups must adhere to consensus-based due process requirements.  These requirements apply to activities related to the development of consensus for approval, revision, reaffirmation, and withdrawal of Community Specifications.  Due process means that any person (organization, company, government agency, individual, etc.) with a direct and material interest has a right to participate by: a) expressing a position and its basis, b) having that position considered, and c) having the right to appeal. Due process allows for equity and fair play. The following constitute the minimum acceptable due process requirements for the development of consensus.
+
+**3.1.	Openness.**  Participation shall be open to all persons who are directly and materially affected by the activity in question. There shall be no undue financial barriers to participation. Voting membership on the consensus body shall not be conditional upon membership in any organization, nor unreasonably restricted on the basis of technical qualifications or other such requirements.  Membership in a Working Group’s parent organization, if any, may be required.
+
+**3.2.	Lack of Dominance.**  The development process shall not be dominated by any single interest category, individual or organization. Dominance means a position or exercise of dominant authority, leadership, or influence by reason of superior leverage, strength, or representation to the exclusion of fair and equitable consideration of other viewpoints.
+
+**3.3.	Balance.**  The development process should have a balance of interests. Participants from diverse interest categories shall be sought with the objective of achieving balance.
+
+**3.4.	Coordination and Harmonization.**  Good faith efforts shall be made to resolve potential conflicts between and among deliverables developed under this Working Group and existing industry standards.
+
+**3.5.	Consideration of Views and Objections.**  Prompt consideration shall be given to the written views and objections of all Participants.
+
+**3.6.	Written procedures.**  This governance document and other materials documenting the Community Specification development process shall be available to any interested person.
+
+## 4.	Specification Development Process.
+
+**4.1.	Pre-Draft.**  Any Participant may submit a proposed initial draft document as a candidate Draft Specification of that Working Group.  The Maintainer will designate each submission as a “Pre-Draft” document.
+
+**4.2.	Draft.**  Each Pre-Draft document of a Working Group must first be Approved to become a” Draft Specification”.  Once the Working Group approves a document as a Draft Specification, the Draft Specification becomes the basis for all going forward work on that specification.
+
+**4.3.	Working Group Approval.**  Once a Working Group believes it has achieved the objectives for its specification as described in the Scope, it will Approve that Draft Specification and progress it to “Approved Specification” status.
+
+**4.4.	Publication and Submission.**  Upon the designation of a Draft Specification as an Approved Specification, the Maintainer will publish the Approved Specification in a manner agreed upon by the Working Group Participants (i.e., Working Group Participant only location, publicly available location, Working Group maintained website, Working Group member website, etc.).  The publication of an Approved Specification in a publicly accessible manner must include the terms under which the Approved Specification is being made available under.
+
+**4.5.	Submissions to Standards Bodies.**  No Draft Specification or Approved Specification may be submitted to another standards development organization without Working group Approval. Upon reaching Approval, the Maintainer will coordinate the submission of the applicable Draft Specification or Approved Specification to another standards development organization. Working Group Participants that developed that Draft Specification or Approved Specification agree to grant the copyright rights necessary to make those submissions.
+
+## 5. Non-Confidential, Restricted Disclosure.
+
+Information disclosed in connection with any Working Group activity, including but not limited to meetings, Contributions, and submissions, is not confidential, regardless of any markings or statements to the contrary.  Notwithstanding the foregoing, if the Working Group is collaborating via a private repository, the Participants will not make any public disclosures of that information contained in that private repository without the Approval of the Working Group.

--- a/LICENSE
+++ b/LICENSE
@@ -18,6 +18,7 @@ This project uses a multi-license structure based on the type of content:
    License file: LICENSE-CSL-1.0
    Specification scope: mitigations/SCOPE.md
    Notices (license acceptance, withdrawals, exclusions): mitigations/NOTICES.md
+   Governance: GOVERNANCE.md
 
    Transition note: Mitigation content contributed on or before 2026-06-10
    was contributed under CC BY 4.0 and remains licensed under CC BY 4.0.
@@ -38,3 +39,8 @@ The full text of each license is provided in the respective files within this re
 
 By contributing to this project, you agree that your contributions will be licensed under
 the applicable license based on the type and location of the content, as described above.
+
+Copyright © Secure Agentic Framework a Series of LF Projects, LLC
+
+For web site terms of use, trademark policy and other project policies please see
+https://lfprojects.org.

--- a/README.md
+++ b/README.md
@@ -184,3 +184,13 @@ This project uses a multi-license structure based on the type of content:
 - **Code** (scripts, detection rules, and software) is licensed under [Apache 2.0](LICENSE-APACHE-2.0)
 
 See [LICENSE](LICENSE) for full details, [mitigations/SCOPE.md](mitigations/SCOPE.md) for the mitigation specification's scope, and [mitigations/NOTICES.md](mitigations/NOTICES.md) for Community Specification License notices.
+
+## Governance
+
+The mitigations specification is developed as a Community Specification Working Group under the [Community Specification Governance Policy 1.0](GOVERNANCE.md). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute.
+
+---
+
+Copyright © Secure Agentic Framework a Series of LF Projects, LLC
+
+For web site terms of use, trademark policy and other project policies please see https://lfprojects.org.

--- a/mitigations/NOTICES.md
+++ b/mitigations/NOTICES.md
@@ -2,11 +2,13 @@
 
 This file applies to the SAF-MCP Mitigations specification (`mitigations/`
 and `MITIGATIONS.md`), which is developed under the
-[Community Specification License 1.0](../LICENSE-CSL-1.0).
+[Community Specification License 1.0](../LICENSE-CSL-1.0) and governed by the
+[Community Specification Governance Policy 1.0](../GOVERNANCE.md). The Working
+Group's scope is defined in [SCOPE.md](SCOPE.md).
 
 ## Code of Conduct
 
-This project follows the [CNCF Code of Conduct](../CODE_OF_CONDUCT.md).
+This project follows the [Contributor Covenant Code of Conduct](../CODE_OF_CONDUCT.md).
 
 Contact for Code of Conduct issues or inquiries:
 

--- a/mitigations/SCOPE.md
+++ b/mitigations/SCOPE.md
@@ -22,3 +22,8 @@ This Scope does not include:
   which is licensed under the Apache License, Version 2.0
 
 Any changes of Scope are not retroactive.
+
+This Working Group is governed by the
+[Community Specification Governance Policy 1.0](../GOVERNANCE.md). Notices,
+including license acceptance, withdrawals, and patent exclusions, are recorded
+in [NOTICES.md](NOTICES.md).


### PR DESCRIPTION
## Summary

- Add `GOVERNANCE.md` defining roles, consensus-based decision-making, appeals, due-process requirements, and the specification lifecycle for the SAF-MCP Mitigations Working Group.
- Replace the CNCF Code of Conduct with Contributor Covenant 2.0 and document repository-specific reporting contacts.
- Link the governance policy from the README, contributing guide, license, specification scope, and notices.
- Add LF Projects copyright and policy references.

## Motivation

The mitigations specification is licensed under the Community Specification License 1.0 but lacked the corresponding documented governance process. These changes establish how the Working Group operates and clarify which repository content is governed by that process.

## Scope

The governance policy applies to `mitigations/` and `MITIGATIONS.md`. Techniques documentation, code, and other out-of-scope material retain their existing governance and licensing treatment.

## Validation

- Confirmed all referenced local documents exist.
- Ran `git diff --cached --check` before committing.
- Normalized Markdown line endings and trailing whitespace.
- Included the required DCO sign-off.
