### PR TITLE
Consolidate duplicate authorization-server techniques

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Profiles scope an atomic technique without changing its permanent ID. A techniqu
 | Profile | Active Techniques | Scope |
 | --- | ---: | --- |
 | SAF Core | 32 | Mechanisms that materially depend on model-mediated decisions, delegated action, dynamic context, memory, or agent coordination. |
-| MCP Profile | 78 | Mechanisms expressed through Model Context Protocol hosts, clients, servers, tools, resources, prompts, sampling, authorization, or transports. |
+| MCP Profile | 77 | Mechanisms expressed through Model Context Protocol hosts, clients, servers, tools, resources, prompts, sampling, authorization, or transports. |
 | Code-Agent Profile | 12 | Mechanisms specific to coding assistants, developer workstations, repositories, build systems, shells, and file-oriented agents. |
 | RAG and Memory Profile | 6 | Mechanisms involving retrieval indexes, embeddings, persistent context, shared memory, or retrieval-augmented generation. |
 | Financial-Agent Profile | 2 | Mechanisms involving delegated payment, trading, blockchain, or other financial authority. |
@@ -100,11 +100,11 @@ Techniques are listed under every applicable tactic; counts therefore represent 
 | Persistence | [SAF-T1206](techniques/SAF-T1206/README.md) | Credential Implant in Config | MCP Profile, Code-Agent Profile | This technique covers an adversary writing or replacing a credential, credential reference, or client-registration identity in persistent MCP or agent configuration so later connections authenticate with an attacker-selected identity. |
 | Persistence | [SAF-T1207](techniques/SAF-T1207/README.md) | Hijack Update Mechanism | MCP Profile | SAF-T1207 covers an adversary causing the normal update path of an already trusted MCP or agentic component to accept and activate an attacker-selected replacement, preserving adversary-controlled code across restarts. |
 | Privilege Escalation | [SAF-T1008](techniques/SAF-T1008/README.md) | Cross-Server Tool Shadowing | SAF Core, MCP Profile | Tool shadowing is cross-server descriptor interference: text supplied for an attacker-controlled tool changes how an agent selects, configures, or invokes a distinct tool from a trusted server. |
+| Privilege Escalation | [SAF-T1009](techniques/SAF-T1009/README.md) | Authorization Server Mix-up | MCP Profile | This technique covers an attacker-controlled or compromised authorization server causing a multi-authorization-server MCP client to misattribute a browser-delivered response from an honest issuer and send the resulting code or token to the attacker-controlled server. |
 | Privilege Escalation | [SAF-T1302](techniques/SAF-T1302/README.md) | Agentic Confused Deputy | SAF Core, MCP Profile | Agentic Confused Deputy covers a low-trust requestor or untrusted input causing an agent to exercise a legitimate tool, service identity, or approved process with authority unavailable to that principal because requestor authorization, scope binding, or action-bound approval is absent or ineffective. |
 | Privilege Escalation | [SAF-T1303](techniques/SAF-T1303/README.md) | Sandbox Escape via Server Exec | MCP Profile, Code-Agent Profile | This technique covers attacker-controlled MCP configuration or tool input reaching a server-side process launcher and escaping the caller's intended sandbox or authorization boundary into a more-privileged service, container, or host context. |
 | Privilege Escalation | [SAF-T1304](techniques/SAF-T1304/README.md) | Credential Relay Chain | MCP Profile | Credential Relay Chain covers an MCP or agent intermediary causing a credential to cross a resource, principal, or hop boundary without independent issuance and validation for the current caller and target, so the receiving component authorizes greater access than the caller otherwise has. |
 | Privilege Escalation | [SAF-T1305](techniques/SAF-T1305/README.md) | Host OS Priv-Esc (RCE) | MCP Profile, Code-Agent Profile | This technique covers exploitation of an MCP host-side client, proxy, inspector, or server flaw that changes an attacker's authority from MCP-level or low-privileged interaction to arbitrary host operating-system code execution in the vulnerable process account. |
-| Privilege Escalation | [SAF-T1306](techniques/SAF-T1306/README.md) | Rogue Authorization Server | MCP Profile | This technique covers a multi-authorization-server MCP flow in which a rogue or compromised authorization server causes the client to misassociate an honest server's authorization response and disclose the resulting code or token to the rogue endpoint. |
 | Privilege Escalation | [SAF-T1307](techniques/SAF-T1307/README.md) | Confused Deputy Attack | MCP Profile | This technique covers an attacker causing an MCP or agentic intermediary to use authority, identity, network reach, or execution capability unavailable to the attacker because the intermediary fails to preserve or enforce the initiating principal's identity, resource, authorization intent, or approved delegation. |
 | Privilege Escalation | [SAF-T1308](techniques/SAF-T1308/README.md) | Token Scope Substitution | MCP Profile | Token Scope Substitution is the use of a valid token, authorization code, or refresh grant under an audience, resource, or operation-scope context that was not bound to the original authorization. |
 | Defense Evasion | [SAF-T1401](techniques/SAF-T1401/README.md) | Line Jumping | MCP Profile | Line Jumping covers an attacker causing an MCP tool, prompt, or resource under attacker influence to win a host, proxy, or registry resolution decision ahead of a trusted competing object. |
@@ -168,6 +168,7 @@ Deprecated IDs remain permanent and navigable for provenance. Use their active r
 | [SAF-T1109](techniques/SAF-T1109/README.md) | Debugging Tool Exploitation | [SAF-T1005](techniques/SAF-T1005/README.md) — Exposed Endpoint Exploit<br>[SAF-T1101](techniques/SAF-T1101/README.md) — Command Injection |
 | [SAF-T1205](techniques/SAF-T1205/README.md) | Persistent Tool Redefinition | [SAF-T1201](techniques/SAF-T1201/README.md) — Post-Approval Tool Mutation |
 | [SAF-T1301](techniques/SAF-T1301/README.md) | Cross-Server Tool Shadowing | [SAF-T1008](techniques/SAF-T1008/README.md) — Cross-Server Tool Shadowing |
+| [SAF-T1306](techniques/SAF-T1306/README.md) | Rogue Authorization Server | [SAF-T1009](techniques/SAF-T1009/README.md) — Authorization Server Mix-up |
 | [SAF-T1309](techniques/SAF-T1309/README.md) | Privileged Tool Invocation via Prompt Manipulation | [SAF-T1102](techniques/SAF-T1102/README.md) — Prompt Injection (Multiple Vectors)<br>[SAF-T1302](techniques/SAF-T1302/README.md) — Agentic Confused Deputy |
 | [SAF-T1912](techniques/SAF-T1912/README.md) | Stego Response Exfil | [SAF-T1902](techniques/SAF-T1902/README.md) — Response-Borne Covert Channel |
 
@@ -175,8 +176,8 @@ Deprecated IDs remain permanent and navigable for provenance. Use their active r
 
 - **Tactics**: 14
 - **Registered technique IDs**: 86
-- **Active techniques**: 80
-- **Deprecated compatibility IDs**: 6
+- **Active techniques**: 79
+- **Deprecated compatibility IDs**: 7
 - **Active technique-to-tactic mappings**: 82
 
 | Tactic | Active Technique Mappings |

--- a/detections/COVERAGE.md
+++ b/detections/COVERAGE.md
@@ -6,8 +6,8 @@ This matrix links active SAF techniques to their native analytics and normalized
 
 ## Summary
 
-- Active techniques with a native analytic: **80 of 80**
-- Native mapping relationships: **0 direct**, **80 partial**, **0 adjacent**
+- Active techniques with a native analytic: **79 of 79**
+- Native mapping relationships: **0 direct**, **79 partial**, **0 adjacent**
 - Validated external mappings: **0**
 - Unrepresented native observation modalities: **`static`**
 
@@ -22,8 +22,8 @@ A mapping may represent more than one modality, so these counts overlap.
 | `runtime` | 70 |
 | `gateway` | 16 |
 | `endpoint` | 14 |
-| `identity` | 20 |
-| `network` | 16 |
+| `identity` | 19 |
+| `network` | 15 |
 | `memory` | 5 |
 | `multimodal` | 1 |
 | `model-lifecycle` | 1 |
@@ -43,7 +43,7 @@ A mapping may represent more than one modality, so these counts overlap.
 | [SAF-T1207](../techniques/SAF-T1207/README.md) — Hijack Update Mechanism | [rule](../techniques/SAF-T1207/detection-rule.yml) | `partial` | `fixture_tested` | `runtime` | — |
 | [SAF-T1008](../techniques/SAF-T1008/README.md) — Cross-Server Tool Shadowing | [rule](../techniques/SAF-T1008/detection-rule.yml) | `partial` | `fixture_tested` | `content`, `runtime` | — |
 | [SAF-T1101](../techniques/SAF-T1101/README.md) — Command Injection | [rule](../techniques/SAF-T1101/detection-rule.yml) | `partial` | `fixture_tested` | `endpoint`, `runtime` | — |
-| [SAF-T1009](../techniques/SAF-T1009/README.md) — Authorization Server Mix-up | [rule](../techniques/SAF-T1009/detection-rule.yml) | `partial` | `fixture_tested` | `gateway`, `identity`, `network` | — |
+| [SAF-T1009](../techniques/SAF-T1009/README.md) — Authorization Server Mix-up | [rule](../techniques/SAF-T1009/detection-rule.yml) | `partial` | `fixture_tested` | `gateway`, `identity`, `network`, `runtime` | — |
 | [SAF-T1102](../techniques/SAF-T1102/README.md) — Prompt Injection (Multiple Vectors) | [rule](../techniques/SAF-T1102/detection-rule.yml) | `partial` | `fixture_tested` | `content`, `runtime` | — |
 | [SAF-T1103](../techniques/SAF-T1103/README.md) — Fake Tool Invocation (Function Spoofing) | [rule](../techniques/SAF-T1103/detection-rule.yml) | `partial` | `fixture_tested` | `runtime` | — |
 | [SAF-T1105](../techniques/SAF-T1105/README.md) — Path Traversal via File Tool | [rule](../techniques/SAF-T1105/detection-rule.yml) | `partial` | `fixture_tested` | `endpoint`, `gateway`, `runtime` | — |
@@ -59,7 +59,6 @@ A mapping may represent more than one modality, so these counts overlap.
 | [SAF-T1304](../techniques/SAF-T1304/README.md) — Credential Relay Chain | [rule](../techniques/SAF-T1304/detection-rule.yml) | `partial` | `fixture_tested` | `gateway`, `identity`, `runtime` | — |
 | [SAF-T1303](../techniques/SAF-T1303/README.md) — Sandbox Escape via Server Exec | [rule](../techniques/SAF-T1303/detection-rule.yml) | `partial` | `fixture_tested` | `endpoint`, `runtime` | — |
 | [SAF-T1305](../techniques/SAF-T1305/README.md) — Host OS Priv-Esc (RCE) | [rule](../techniques/SAF-T1305/detection-rule.yml) | `partial` | `fixture_tested` | `endpoint`, `runtime` | — |
-| [SAF-T1306](../techniques/SAF-T1306/README.md) — Rogue Authorization Server | [rule](../techniques/SAF-T1306/detection-rule.yml) | `partial` | `fixture_tested` | `identity`, `network`, `runtime` | — |
 | [SAF-T1307](../techniques/SAF-T1307/README.md) — Confused Deputy Attack | [rule](../techniques/SAF-T1307/detection-rule.yml) | `partial` | `fixture_tested` | `gateway`, `identity`, `runtime` | — |
 | [SAF-T1308](../techniques/SAF-T1308/README.md) — Token Scope Substitution | [rule](../techniques/SAF-T1308/detection-rule.yml) | `partial` | `fixture_tested` | `identity`, `runtime` | — |
 | [SAF-T1406](../techniques/SAF-T1406/README.md) — Metadata Manipulation | [rule](../techniques/SAF-T1406/detection-rule.yml) | `partial` | `fixture_tested` | `content`, `runtime` | — |

--- a/detections/registry.yml
+++ b/detections/registry.yml
@@ -25,7 +25,7 @@ techniques:
   SAF-T1101:
     modalities: [endpoint, runtime]
   SAF-T1009:
-    modalities: [gateway, identity, network]
+    modalities: [gateway, identity, network, runtime]
   SAF-T1102:
     modalities: [content, runtime]
   SAF-T1103:
@@ -56,8 +56,6 @@ techniques:
     modalities: [endpoint, runtime]
   SAF-T1305:
     modalities: [endpoint, runtime]
-  SAF-T1306:
-    modalities: [identity, network, runtime]
   SAF-T1307:
     modalities: [gateway, identity, runtime]
   SAF-T1308:

--- a/research/framework-model.yml
+++ b/research/framework-model.yml
@@ -597,11 +597,11 @@ techniques:
   - mcp
   tactics:
   - ATK-TA0001
+  - ATK-TA0004
   summary: This technique covers an attacker-controlled or compromised authorization server causing a multi-authorization-server
     MCP client to misattribute a browser-delivered response from an honest issuer and send the resulting code or
     token to the attacker-controlled server. The crossed boundary is the client's per-request binding among the
-    validated expected issuer, callback, and token endpoint. MCP authorization security considerations OAuth Security
-    BCP
+    validated expected issuer, callback, and token endpoint.
   technique_path: techniques/SAF-T1009/README.md
   research_packet: research/techniques/SAF-T1009
   relationships:
@@ -609,7 +609,13 @@ techniques:
     type: related_to
   - target: SAF-T1007
     type: related_to
+  - target: SAF-T1304
+    type: related_to
   - target: SAF-T1306
+    type: replaces
+  - target: SAF-T1308
+    type: related_to
+  - target: SAF-T1406
     type: related_to
   - target: SAF-T1408
     type: related_to
@@ -1435,6 +1441,8 @@ techniques:
   relationships:
   - target: SAF-T1302
     type: related_to
+  - target: SAF-T1009
+    type: related_to
   - target: SAF-T1306
     type: related_to
   - target: SAF-T1308
@@ -1554,8 +1562,8 @@ techniques:
     validation_level: fixture_tested
 - technique_id: SAF-T1306
   name: Rogue Authorization Server
-  lifecycle_status: active
-  documentation_status: under_review
+  lifecycle_status: deprecated
+  documentation_status: deprecated
   evidence_status: research-derived
   profiles:
   - mcp
@@ -1567,18 +1575,25 @@ techniques:
   technique_path: techniques/SAF-T1306/README.md
   research_packet: research/techniques/SAF-T1306
   relationships:
-  - target: SAF-T1009
-    type: related_to
   - target: SAF-T1304
-    type: related_to
-  - target: SAF-T1308
     type: related_to
   - target: SAF-T1406
     type: related_to
-  - target: SAF-T1408
-    type: related_to
   - target: SAF-T1507
     type: related_to
+  - target: SAF-T1308
+    type: related_to
+  - target: SAF-T1408
+    type: related_to
+  - target: SAF-T1009
+    type: replaced_by
+  replaced_by:
+  - SAF-T1009
+  deprecation:
+    decision: SAF-TAX-013
+    reason: The frozen contracts define the same multi-authorization-server issuer-misbinding mechanism and immediate
+      cross-issuer authorization-code or token disclosure. A rogue server is a prerequisite and actor role, not a
+      separate technique.
   mitigations:
   - SAF-M-12
   - SAF-M-13
@@ -1722,6 +1737,8 @@ techniques:
     type: related_to
   - target: SAF-T1304
     type: related_to
+  - target: SAF-T1009
+    type: related_to
   - target: SAF-T1306
     type: related_to
   - target: SAF-T1706
@@ -1764,6 +1781,8 @@ techniques:
   - target: SAF-T1102
     type: related_to
   - target: SAF-T1205
+    type: related_to
+  - target: SAF-T1009
     type: related_to
   - target: SAF-T1306
     type: related_to

--- a/research/taxonomy-review.yml
+++ b/research/taxonomy-review.yml
@@ -200,7 +200,7 @@ decisions:
   type: profile_reconciliation
   scope: all_active_techniques
   saf_core_count: 32
-  mcp_profile_count: 78
+  mcp_profile_count: 77
   evidence_inputs:
   - research/framework-model.yml
   - research/techniques/*/technique-contract.yml
@@ -210,6 +210,25 @@ decisions:
     agent action. Generic protocol, OAuth, endpoint, package, parser, binary, and
     transport behaviors remain admitted through their explicit domain profiles
     without being mislabeled as core agentic mechanisms.
+  status: implemented
+- id: SAF-TAX-013
+  type: consolidation
+  canonical: SAF-T1009
+  canonical_name: Authorization Server Mix-up
+  deprecated:
+  - SAF-T1306
+  tactics:
+  - ATK-TA0001
+  - ATK-TA0004
+  evidence_inputs:
+  - research/techniques/SAF-T1009/technique-contract.yml
+  - research/techniques/SAF-T1306/technique-contract.yml
+  rationale: >-
+    Both frozen contracts require a multi-authorization-server client to
+    misbind an honest issuer's authorization response and disclose its code or
+    token to an attacker-controlled authorization server. The rogue server is
+    an actor and prerequisite, while Initial Access and Privilege Escalation
+    are tactic mappings for the same mechanism.
   status: implemented
 research_backlog:
 - id: SAF-RESEARCH-RECON-001

--- a/research/techniques/SAF-T1009/technique-contract.yml
+++ b/research/techniques/SAF-T1009/technique-contract.yml
@@ -3,12 +3,13 @@ technique_id: SAF-T1009
 name: Authorization Server Mix-up
 status: complete
 created_on: "2026-09-01"
-updated_on: "2026-09-01"
+updated_on: "2026-09-02"
 generation_mode: clean_room
 trace_format: hidden_html_v1
 
 tactics:
   - ATK-TA0001
+  - ATK-TA0004
 
 adversary_objective: >-
   Cause a multi-authorization-server MCP client to disclose an authorization

--- a/research/techniques/SAF-T1009/traceability-ledger.yml
+++ b/research/techniques/SAF-T1009/traceability-ledger.yml
@@ -2,10 +2,13 @@ version: 1
 technique_id: SAF-T1009
 policy: source_or_omit
 review_status: passed
-reviewed_on: '2026-09-01'
+reviewed_on: '2026-09-02'
 publishable_artifact: techniques/SAF-T1009/README.md
 coverage: all_substantive_publishable_content
 repository_sources:
+- id: LOCAL-taxonomy-review
+  path: research/taxonomy-review.yml
+  supports: Framework Model v2 duplicate-consolidation decision, canonical ID, tactic reconciliation, and compatibility relationship.
 - id: LOCAL-contract
   path: research/techniques/SAF-T1009/technique-contract.yml
   supports: Internal scope, seed name, tactic, completion criteria, and reconciled

--- a/research/techniques/SAF-T1306/traceability-ledger.yml
+++ b/research/techniques/SAF-T1306/traceability-ledger.yml
@@ -2,10 +2,13 @@ version: 1
 technique_id: SAF-T1306
 policy: source_or_omit
 review_status: passed
-reviewed_on: '2026-09-01'
+reviewed_on: '2026-09-02'
 publishable_artifact: techniques/SAF-T1306/README.md
 coverage: all_substantive_publishable_content
 repository_sources:
+- id: LOCAL-taxonomy-review
+  path: research/taxonomy-review.yml
+  supports: Framework Model v2 duplicate-consolidation decision, replacement ID, and compatibility status.
 - id: LOCAL-contract
   path: research/techniques/SAF-T1306/technique-contract.yml
   supports: Internal scope, name, tactic, canonical neighbor boundaries, and completion

--- a/techniques/SAF-T1009/README.md
+++ b/techniques/SAF-T1009/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-- **Tactic**: Initial Access (ATK-TA0001)
+- **Tactic**: Initial Access (ATK-TA0001); Privilege Escalation (ATK-TA0004)
 - **Technique ID**: SAF-T1009
 - **Research Packet**: [research/techniques/SAF-T1009](../../research/techniques/SAF-T1009/)
 - **Traceability Ledger**: [traceability-ledger.yml](../../research/techniques/SAF-T1009/traceability-ledger.yml)
@@ -11,7 +11,7 @@
 - **Severity**: High
 - **Severity Rationale**: A successful mix-up can disclose an authorization code or access token for an honest issuer, with confidentiality and integrity impact bounded by the credential's permissions and the downstream resource controls. [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207.html) <!-- SAF-TRACE: claims=SAF-T1009-C005; sources=SRC-rfc9207 -->
 - **First Observed**: Not observed in MCP production in the reviewed corpus; the generic OAuth behavior was demonstrated on concrete clients by Fett, Küsters, and Schmitz in 2016. [Formal OAuth analysis](https://arxiv.org/abs/1601.01229) <!-- SAF-TRACE: claims=SAF-T1009-C012,SAF-T1009-C017; sources=SRC-fett-oauth-analysis,SRC-nvd-oauth-mixup-query -->
-- **Last Updated**: 2026-09-01
+- **Last Updated**: 2026-09-02
 
 ## Scope
 
@@ -221,7 +221,7 @@ The standalone experimental analytic is maintained in [detection-rule.yml](detec
 | --- | --- | --- |
 | [SAF-T1507: Authorization Code Interception](../SAF-T1507/README.md) | Follow-on or adjacent | Obtains an authorization code through interception; SAF-T1009 instead causes cross-issuer response misbinding and can then disclose the code. [RFC 9700 §§4.4-4.5](https://www.rfc-editor.org/rfc/rfc9700.html#section-4.4) <!-- SAF-TRACE: claims=SAF-T1009-C003; sources=SRC-rfc9700 --> |
 | [SAF-T1706: OAuth Token Pivot Replay](../SAF-T1706/README.md) | Alternative boundary failure | Reuses an issued token across contexts; SAF-T1009 occurs earlier at issuer and endpoint binding. [RFC 8707 §3](https://www.rfc-editor.org/rfc/rfc8707.html#section-3) <!-- SAF-TRACE: claims=SAF-T1009-C011; sources=SRC-rfc8707 --> |
-| [SAF-T1306: Rogue Authorization Server](../SAF-T1306/README.md) | Prerequisite or adjacent | Controls or advertises the malicious authorization endpoint; it becomes SAF-T1009 only when an honest issuer's browser response is misbound and its credential is disclosed across issuers. [Malicious Endpoints research](https://arxiv.org/abs/1508.04324) <!-- SAF-TRACE: claims=SAF-T1009-C004,SAF-T1009-C013; sources=SRC-mainka-oidc-endpoints,SRC-fett-oauth-analysis --> |
+| [SAF-T1306: Rogue Authorization Server](../SAF-T1306/README.md) | Deprecated compatibility ID | Its frozen contract describes the same cross-issuer response-misbinding and credential-disclosure mechanism. Use SAF-T1009 for new mappings. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml) |
 
 ## MITRE ATT&CK Mapping
 
@@ -255,3 +255,4 @@ The standalone experimental analytic is maintained in [detection-rule.yml](detec
 | Version | Date | Changes | Author |
 | --- | --- | --- | --- |
 | 0.1 | 2026-09-01 | Independent clean-room research draft and tested analytic. | OpenAI Codex clean-room agent |
+| 0.2 | 2026-09-02 | Consolidated the duplicate SAF-T1306 compatibility ID and reconciled tactics and relationships under SAF-TAX-013. | The SAF-MCP Authors |

--- a/techniques/SAF-T1306/README.md
+++ b/techniques/SAF-T1306/README.md
@@ -6,12 +6,15 @@
 - **Technique ID**: SAF-T1306
 - **Research Packet**: [research/techniques/SAF-T1306](../../research/techniques/SAF-T1306/)
 - **Traceability Ledger**: [traceability-ledger.yml](../../research/techniques/SAF-T1306/traceability-ledger.yml)
-- **Documentation Status**: Under Review
+- **Lifecycle Status**: Deprecated. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml)
+- **Documentation Status**: Deprecated
 - **Evidence Status**: Research-Derived
 - **Severity**: High
 - **Severity Rationale**: A successful flow can disclose a victim-bound authorization code or token, with consequence bounded by scope, audience, lifetime, sender constraint, and downstream authorization. <!-- SAF-TRACE: claims=SAF-T1306-C018,SAF-T1306-C024; sources=SRC-rfc9700,SRC-mcp-sep-2468,SRC-mcp-authorization-2026-07-28 -->
 - **First Observed**: Not observed in an MCP production incident in the authoritative corpus reviewed through 2026-09-01. <!-- SAF-TRACE: claims=SAF-T1306-C009; sources=SRC-mcp-release-2026-07-28,SRC-cisa-kev-2026-09-01,SRC-nvd-cve-2025-10619,SRC-nvd-cve-2025-4143 -->
-- **Last Updated**: 2026-09-01
+- **Last Updated**: 2026-09-02
+
+> **Deprecated compatibility ID:** SAF-T1306 is consolidated into [SAF-T1009: Authorization Server Mix-up](../SAF-T1009/README.md). Both frozen contracts define the same issuer-misbinding and cross-issuer credential-disclosure mechanism. This page and its evidence packet remain available for provenance; use SAF-T1009 for new mappings. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml)
 
 ## Scope
 
@@ -238,3 +241,4 @@ The standalone example analytic is maintained in [detection-rule.yml](detection-
 | Version | Date | Changes | Author |
 | --- | --- | --- | --- |
 | 0.1 | 2026-09-01 | Initial clean-room research draft | Unattributed; project technique author not established from allowed inputs |
+| 0.2 | 2026-09-02 | Deprecated as a compatibility ID after consolidation into SAF-T1009 under SAF-TAX-013; retained the original evidence and attribution record. | The SAF-MCP Authors |

--- a/techniques/SAF-T1308/README.md
+++ b/techniques/SAF-T1308/README.md
@@ -198,7 +198,7 @@ The standalone analytic is maintained in [detection-rule.yml](detection-rule.yml
 | --- | --- | --- |
 | [SAF-T1202: OAuth Token Persistence](../SAF-T1202/README.md) | Prerequisite or alternative | Acquires or reuses a token within its valid context; Token Scope Substitution changes or misinterprets the authorization context. <!-- SAF-TRACE: claims=SAF-T1308-C018; sources=SRC-mitre-t1550-001 --> |
 | [SAF-T1304: Credential Relay Chain](../SAF-T1304/README.md) | Co-occurring | Propagates a credential across a downstream authorization boundary; substitution can occur without forwarding. <!-- SAF-TRACE: claims=SAF-T1308-C018; sources=SRC-mcp-security-2025-11-25 --> |
-| [SAF-T1306: Rogue Authorization Server](../SAF-T1306/README.md) | Overlapping | Uses attacker-controlled authorization infrastructure and issuer misbinding; substitution authorizes a resource or operation outside the binding actually granted. <!-- SAF-TRACE: claims=SAF-T1308-C018; sources=SRC-mcp-security-2025-11-25 --> |
+| [SAF-T1009: Authorization Server Mix-up](../SAF-T1009/README.md) | Overlapping | Uses attacker-controlled authorization infrastructure and issuer misbinding; substitution authorizes a resource or operation outside the binding actually granted. <!-- SAF-TRACE: claims=SAF-T1308-C018; sources=SRC-mcp-security-2025-11-25 --> |
 
 ## MITRE ATT&CK Mapping
 

--- a/techniques/SAF-T1408/README.md
+++ b/techniques/SAF-T1408/README.md
@@ -198,7 +198,6 @@ The standalone experimental analytic is maintained in [detection-rule.yml](detec
 | Technique | Relationship | Distinction |
 | --- | --- | --- |
 | [SAF-T1009: Authorization Server Mix-up](../SAF-T1009/README.md) | Alternative or co-occurring | Changes the issuer or credential endpoint; this technique weakens PKCE inside the selected flow. <!-- SAF-TRACE: claims=SAF-T1408-C016; sources=SRC-rfc9700 --> |
-| [SAF-T1306: Rogue Authorization Server](../SAF-T1306/README.md) | Prerequisite or alternative | Uses an attacker-controlled authorization server or redirect path; this technique changes the accepted protection method. <!-- SAF-TRACE: claims=SAF-T1408-C016; sources=SRC-mcp-security-2025-11-25 --> |
 
 ## MITRE ATT&CK Mapping
 


### PR DESCRIPTION
## Summary

- consolidate SAF-T1306 into canonical SAF-T1009
- retain SAF-T1306 as a permanent deprecated compatibility ID with provenance
- reconcile tactic, framework relationship, detection registry, catalog, and traceability metadata
- retain SAF-T1302 and SAF-T1307 as a documented parent/specialization pair rather than merging them

## Validation

- python3 -m unittest discover -s scripts -p 'test_*.py'
- python3 scripts/validate-technique-research.py --all
- python3 scripts/validate-framework-model.py
- python3 scripts/generate-technique-catalog.py --check
- python3 scripts/validate-detection-registry.py
- git diff --check