### PR TITLE
Refine technique family boundaries and admission status

### DIFF
--- a/research/framework-model.yml
+++ b/research/framework-model.yml
@@ -2997,10 +2997,12 @@ techniques:
   relationships:
   - target: SAF-T1102
     type: related_to
+  - target: SAF-T1802
+    type: related_to
   - target: SAF-T1803
-    type: related_to
+    type: has_specialization
   - target: SAF-T1804
-    type: related_to
+    type: has_specialization
   - target: SAF-T1910
     type: related_to
   - target: SAF-T1911
@@ -3044,6 +3046,8 @@ techniques:
   research_packet: research/techniques/SAF-T1803
   relationships:
   - target: SAF-T1801
+    type: specialization_of
+  - target: SAF-T1802
     type: related_to
   - target: SAF-T1804
     type: related_to
@@ -3132,7 +3136,7 @@ techniques:
   - target: SAF-T1504
     type: related_to
   - target: SAF-T1801
-    type: related_to
+    type: specialization_of
   - target: SAF-T1803
     type: related_to
   mitigations:
@@ -3486,7 +3490,7 @@ techniques:
 - technique_id: SAF-T2102
   name: Service Disruption
   lifecycle_status: active
-  documentation_status: stable
+  documentation_status: under_review
   evidence_status: demonstrated
   profiles:
   - mcp
@@ -3898,6 +3902,10 @@ techniques:
   research_packet: research/techniques/SAF-T1802
   relationships:
   - target: SAF-T1606
+    type: related_to
+  - target: SAF-T1801
+    type: related_to
+  - target: SAF-T1803
     type: related_to
   - target: SAF-T1913
     type: related_to

--- a/research/taxonomy-review.yml
+++ b/research/taxonomy-review.yml
@@ -259,6 +259,44 @@ decisions:
     trigger-conditioned corpus retrieval and an attacker-selected generated
     response while ordinary queries remain substantially unaffected.
   status: implemented
+- id: SAF-TAX-015
+  type: admission_and_atomicity_review
+  retained:
+  - SAF-T1802
+  - SAF-T1803
+  - SAF-T2101
+  - SAF-T2105
+  hierarchy:
+    parent: SAF-T1801
+    specializations:
+    - SAF-T1803
+    - SAF-T1804
+  provisional_family: SAF-T2102
+  evidence_inputs:
+  - research/techniques/SAF-T1801/technique-contract.yml
+  - research/techniques/SAF-T1802/technique-contract.yml
+  - research/techniques/SAF-T1803/technique-contract.yml
+  - research/techniques/SAF-T1804/technique-contract.yml
+  - research/techniques/SAF-T2101/technique-contract.yml
+  - research/techniques/SAF-T2102/technique-contract.yml
+  - research/techniques/SAF-T2105/technique-contract.yml
+  - techniques/SAF-T1802/detection-rule.yml
+  - techniques/SAF-T1803/detection-rule.yml
+  - techniques/SAF-T2101/detection-rule.yml
+  - techniques/SAF-T2102/detection-rule.yml
+  - techniques/SAF-T2105/detection-rule.yml
+  rationale: >-
+    File Collection can complete with one successful file-content read across a
+    path or authorization boundary, while Database Dump requires dump-equivalent
+    database breadth; they are not duplicates. Database Dump and API Data
+    Harvest are source-specific specializations of Automated Data Harvesting.
+    Data Destruction remains atomic at the destructive external side effect.
+    Disinformation Output remains model-native at deliberate deceptive
+    generation. Service Disruption is retained provisionally but returned to
+    Under Review because its current contract groups crash, cross-owner task
+    cancellation, and resource-pressure mechanisms by shared availability
+    outcome.
+  status: implemented
 research_backlog:
 - id: SAF-RESEARCH-RECON-001
   topic: External discovery of public agent or MCP endpoints, registries, capability metadata, and trust relationships.
@@ -266,4 +304,13 @@ research_backlog:
 - id: SAF-RESEARCH-RESOURCE-001
   topic: Development of rogue servers, authorization infrastructure, staged poison content, and agent-specific control infrastructure.
   required_action: Run separate clean-room admission reviews and reject candidates that duplicate Initial Access or Command and Control.
+- id: SAF-RESEARCH-AVAILABILITY-CRASH-001
+  topic: Fault-triggered termination of an MCP or agent service through an attacker-controlled request.
+  required_action: Run a separate clean-room admission review and prove an atomic mechanism and non-duplication before assigning an opaque technique ID.
+- id: SAF-RESEARCH-AVAILABILITY-CANCEL-001
+  topic: Cross-principal cancellation of another principal's in-flight MCP or agent task.
+  required_action: Run a separate clean-room admission review and prove an atomic mechanism and non-duplication before assigning an opaque technique ID.
+- id: SAF-RESEARCH-AVAILABILITY-PRESSURE-001
+  topic: Tool-mediated resource amplification that materially degrades shared agent-service capacity.
+  required_action: Run a separate clean-room admission review and prove an atomic mechanism and non-duplication before assigning an opaque technique ID.
 unresolved: []

--- a/research/techniques/SAF-T1802/traceability-ledger.yml
+++ b/research/techniques/SAF-T1802/traceability-ledger.yml
@@ -6,6 +6,9 @@ reviewed_on: '2026-09-02'
 publishable_artifact: techniques/SAF-T1802/README.md
 coverage: all_substantive_publishable_content
 repository_sources:
+- id: LOCAL-taxonomy-review
+  path: research/taxonomy-review.yml
+  supports: Framework Model v2 admission decision, collection-family hierarchy, and distinctions from automated harvesting and database dumping.
 - id: LOCAL-contract
   path: research/techniques/SAF-T1802/technique-contract.yml
   supports: Internal scope, name, tactic, completion criteria, and synthetic integration

--- a/research/techniques/SAF-T1910/traceability-ledger.yml
+++ b/research/techniques/SAF-T1910/traceability-ledger.yml
@@ -6,6 +6,9 @@ reviewed_on: '2026-09-02'
 publishable_artifact: techniques/SAF-T1910/README.md
 coverage: all_substantive_publishable_content
 repository_sources:
+- id: LOCAL-taxonomy-review
+  path: research/taxonomy-review.yml
+  supports: Framework Model v2 exfiltration-family consolidation, active specializations, and deprecated compatibility relationship.
 - id: LOCAL-contract
   path: research/techniques/SAF-T1910/technique-contract.yml
   supports: Internal scope, name, tactic, neighbor placeholders, and completion conditions.

--- a/research/techniques/SAF-T2102/traceability-ledger.yml
+++ b/research/techniques/SAF-T2102/traceability-ledger.yml
@@ -6,6 +6,9 @@ reviewed_on: '2026-09-02'
 publishable_artifact: techniques/SAF-T2102/README.md
 coverage: all_substantive_publishable_content
 repository_sources:
+- id: LOCAL-taxonomy-review
+  path: research/taxonomy-review.yml
+  supports: Framework Model v2 atomicity review, provisional family classification, documentation-status decision, and follow-up research backlog.
 - id: LOCAL-contract
   path: research/techniques/SAF-T2102/technique-contract.yml
   supports: Scope, tactic, neutral name, neighbor distinctions, telemetry, and completion

--- a/techniques/SAF-T1003/README.md
+++ b/techniques/SAF-T1003/README.md
@@ -7,7 +7,7 @@
 - **Documentation Status**: Under Review
 - **Evidence Status**: observed
 - **Severity**: High, conditional on installation or activation authority
-- **Last Updated**: 2026-09-01
+- **Last Updated**: 2026-09-02
 
 ## Overview
 
@@ -106,7 +106,7 @@ For response, disable the server, preserve configuration and acquisition evidenc
 | SAF-T1203 — Backdoored Server Binary | The neighbor describes malicious artifact state; this technique describes delivery. | <!-- SAF-TRACE: claims=SAF-T1003-C004 ; sources=SRC-mcp-registry-about, SRC-mitre-t1195-002 -->
 | SAF-T1207 — Hijack Update Mechanism | Update-path compromise is defining for the neighbor; this technique does not require mechanism hijack. | <!-- SAF-TRACE: claims=SAF-T1003-C004 ; sources=SRC-mcp-registry-about, SRC-mitre-t1195-002 -->
 
-Neighbor names came only from the permitted catalog ID/name projection and were registered after freeze; SAF-T1207 remains cataloged but awaits its own clean-room technique directory. <!-- SAF-TRACE: claims=SAF-T1003-C004 ; sources=SRC-mcp-registry-about, SRC-mitre-t1195-002 -->
+Neighbor names came only from the permitted catalog ID/name projection and were registered after freeze, as recorded in the [integration notes](../../research/techniques/SAF-T1003/integration/integration-notes.yml).
 
 ## MITRE ATT&CK Mapping
 
@@ -135,3 +135,4 @@ MITRE ATT&CK DET0537 is an adjacent detection strategy correlating atypical deli
 | Version | Date | Changes |
 |---|---|---|
 | 0.1 | 2026-09-01 | Strict clean-room rewrite with source and framework joins complete; final validation awaits cataloged neighbor SAF-T1207. |
+| 0.2 | 2026-09-02 | Reconciled the supply-chain family after SAF-T1207 received its clean-room technique directory. |

--- a/techniques/SAF-T1802/README.md
+++ b/techniques/SAF-T1802/README.md
@@ -220,6 +220,8 @@ The standalone example analytic is maintained in [detection-rule.yml](detection-
 | Technique | Relationship | Distinction |
 | --- | --- | --- |
 | [SAF-T1606: Directory Listing via File Tool](../SAF-T1606/README.md) | Prerequisite or co-occurring | Enumeration returns names or metadata; File Collection requires returned file content. <!-- SAF-TRACE: claims=SAF-T1802-C014; sources=SRC-attack-t1083,SRC-attack-t1005 --> |
+| [SAF-T1801: Automated Data Harvesting](../SAF-T1801/README.md) | Related broader behavior | Automated Data Harvesting requires systematic breadth across repeated retrievals; File Collection can complete with one successful file-content read. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml) |
+| [SAF-T1803: Database Dump](../SAF-T1803/README.md) | Adjacent collection behavior | Database Dump requires dump-equivalent database breadth; File Collection is bounded by retrieval of file content and does not require broad database export. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml) |
 | [SAF-T1913: HTTP POST Exfil](../SAF-T1913/README.md) | Follow-on | Transfer moves already collected content; File Collection's immediate objective is obtaining the content. <!-- SAF-TRACE: claims=SAF-T1802-C001,SAF-T1802-C019; sources=SRC-attack-t1005,SRC-cve-2026-46555 --> |
 
 The isolated placeholders were replaced with canonical neighbors after the clean-room freeze was verified, as recorded in the [integration notes](../../research/techniques/SAF-T1802/integration/integration-notes.yml).
@@ -262,3 +264,4 @@ The isolated placeholders were replaced with canonical neighbors after the clean
 | Version | Date | Changes | Author |
 | --- | --- | --- | --- |
 | 0.1 | 2026-09-02 | Independent clean-room draft, evidence packet, detector, tests, and synthetic strict-validation handoff. | OpenAI Codex clean-room agent |
+| 0.2 | 2026-09-02 | Added the reviewed distinction from automated harvesting and database dumping. | OpenAI Codex taxonomy review |

--- a/techniques/SAF-T1910/README.md
+++ b/techniques/SAF-T1910/README.md
@@ -211,8 +211,11 @@ The standalone experimental analytic is maintained in [detection-rule.yml](detec
 | Technique | Relationship | Distinction |
 | --- | --- | --- |
 | [SAF-T1102: Prompt Injection (Multiple Vectors)](../SAF-T1102/README.md) | Prerequisite or co-occurring | Covers adversarial instruction delivery or model influence; SAF-T1910 requires selected data to cross through a covert carrier. <!-- SAF-TRACE: claims=SAF-T1910-C003,SAF-T1910-C020; sources=SRC-invariant-tpa-2025-04-01,SRC-invariant-whatsapp-mcp-2025-04-07,SRC-agentdojo-2406.13352v3 --> |
-| [SAF-T1911: Parameter Exfiltration](../SAF-T1911/README.md) | Specialization | Uses a tool or protocol parameter as the carrier; SAF-T1910 also includes application messages, URLs, and downstream service side effects. <!-- SAF-TRACE: claims=SAF-T1910-C002,SAF-T1910-C018; sources=SRC-mcp-tools-2025-06-18,SRC-mitre-attack-t1048-v1.6 --> |
-| [SAF-T1912: Stego Response Exfil](../SAF-T1912/README.md) | Specialization | Conceals data in a response; SAF-T1910 covers covert carriers on either tool input or downstream output paths. <!-- SAF-TRACE: claims=SAF-T1910-C002,SAF-T1910-C018; sources=SRC-mcp-tools-2025-06-18,SRC-mitre-attack-t1048-v1.6 --> |
+| [SAF-T1902: Response-Borne Covert Channel](../SAF-T1902/README.md) | Specialization | Requires the covert carrier to be embedded in a response-processing, rendering, or relay path. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml) |
+| [SAF-T1911: Parameter Exfiltration](../SAF-T1911/README.md) | Specialization | Uses a tool or protocol parameter as the carrier; SAF-T1910 also includes application messages, URLs, and downstream service side effects. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml) |
+| [SAF-T1912: Stego Response Exfil](../SAF-T1912/README.md) | Deprecated compatibility ID | Its frozen response-borne carrier contract is consolidated into SAF-T1902; use SAF-T1902 for new mappings. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml) |
+| [SAF-T1913: HTTP POST Exfil](../SAF-T1913/README.md) | Specialization | Requires an HTTP POST request to carry the data outside the authorized boundary. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml) |
+| [SAF-T1914: Tool-to-Tool Exfil](../SAF-T1914/README.md) | Specialization | Requires one tool's output or accessible context to be relayed through another tool to an unauthorized destination. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml) |
 
 ## MITRE ATT&CK Mapping
 
@@ -242,3 +245,4 @@ The standalone experimental analytic is maintained in [detection-rule.yml](detec
 | Version | Date | Changes | Author |
 | --- | --- | --- | --- |
 | 0.1 | 2026-09-02 | Independent clean-room draft with evidence packet and deterministic detection tests. | OpenAI Codex clean-room agent |
+| 0.2 | 2026-09-02 | Reconciled the active exfiltration specializations and deprecated response-carrier compatibility ID. | OpenAI Codex taxonomy review |

--- a/techniques/SAF-T2102/README.md
+++ b/techniques/SAF-T2102/README.md
@@ -4,7 +4,7 @@
 - **Technique ID**: SAF-T2102
 - **Research Packet**: [research/techniques/SAF-T2102/](../../research/techniques/SAF-T2102/)
 - **Traceability Ledger**: [traceability-ledger.yml](../../research/techniques/SAF-T2102/traceability-ledger.yml)
-- **Documentation Status**: Stable
+- **Documentation Status**: Under Review
 - **Evidence Status**: Demonstrated
 - **Severity**: High
 - **Severity Rationale**: A single attacker-controlled request can terminate a service process, cancel another principal's work, or amplify agent-resource use enough to reduce service capacity. <!-- SAF-TRACE: claims=SAF-T2102-C001; sources=SRC-ghsa-j975-95f5-7wqh,SRC-ghsa-python-hvrp,SRC-arxiv-resource-amplification-2026 -->
@@ -20,6 +20,8 @@ Service Disruption is the deliberate use of MCP or agentic-system requests, task
 The defining boundary is crossed when attacker-controlled activity at an MCP or agent interface causes measurable loss of availability, capacity, or task continuity beyond the attacker's own work. <!-- SAF-TRACE: claims=SAF-T2102-C001; sources=SRC-ghsa-j975-95f5-7wqh,SRC-ghsa-python-hvrp,SRC-arxiv-resource-amplification-2026 -->
 
 This technique excludes ordinary provider failures, volumetric network denial outside the MCP interface, downstream data destruction without an availability outcome, and high resource cost that has not produced measurable degradation. <!-- SAF-TRACE: claims=SAF-T2102-C010; sources=SRC-github-availability-2026-07,SRC-arxiv-aegis-2026,SRC-nist-sp800-228-upd1 -->
+
+> **Classification note:** This technique is retained provisionally as an availability family. Its current contract spans fault-triggered termination, cross-principal task cancellation, and resource pressure; those mechanisms must not be treated as interchangeable, and each now requires a separate clean-room admission review before any narrower technique ID is assigned. [Framework Model v2 taxonomy review](../../research/taxonomy-review.yml)
 
 ## Description
 
@@ -125,3 +127,4 @@ The analytic is deterministic but not exhaustive: distributed low-rate activity,
 | Version | Date | Changes |
 |---|---|---|
 | 1.0 | 2026-09-02 | Clean-room research draft with tested detection and frozen evidence packet. |
+| 1.1 | 2026-09-02 | Returned the technique to Under Review and recorded its provisional availability-family classification pending three atomic admission reviews. |


### PR DESCRIPTION
## Summary

- verify and correct the public exfiltration and supply-chain family views
- distinguish File Collection from Database Dump and model Database Dump and API Data Harvest as Automated Data Harvesting specializations
- retain Data Destruction and Disinformation Output after atomicity review
- return Service Disruption to Under Review and backlog separate clean-room reviews for crash, cross-principal cancellation, and resource-pressure mechanisms
- add taxonomy-backed traceability for every new classification statement

## Validation

- `python3 -m unittest discover -s scripts -p "test_*.py"`
- `python3 scripts/validate-technique-research.py --all`
- `python3 scripts/validate-framework-model.py`
- `python3 scripts/generate-technique-catalog.py --check`
- `python3 scripts/validate-detection-registry.py`
- `python3 scripts/generate-detection-coverage.py --check`
- `python3 scripts/generate-mitigation-catalog.py --check`

All checks pass. The private working TODO remains outside the repository.