### PR TITLE
fix(skill): align author-saf-technique with the research validator

### DIFF
--- a/.agents/skills/author-saf-technique/SKILL.md
+++ b/.agents/skills/author-saf-technique/SKILL.md
@@ -45,7 +45,8 @@ Treat these repository files as canonical:
 - `techniques/TEMPLATE.md` for publishable structure;
 - `research/README.md` for repository joins and evidence states;
 - `research/templates/technique/` for the research packet schema;
-- `traceability-ledger.yml` for the source-or-omit audit and excluded leads;
+- `research/techniques/SAF-TXXXX/traceability-ledger.yml` for the source-or-omit
+  audit and excluded leads;
 - `research/source-manifest.yml` for source acquisition records;
 - `research/framework-model.yml` and `research/alignment-ledger.yml` for
   framework reconciliation; and

--- a/.agents/skills/author-saf-technique/references/breach-and-vulnerability-research.md
+++ b/.agents/skills/author-saf-technique/references/breach-and-vulnerability-research.md
@@ -10,7 +10,11 @@ products, and protocol methods across:
 
 - official vendor or project security advisories and postmortems;
 - NVD and the originating CVE Numbering Authority record;
-- GitHub Security Advisories and maintainer security pages;
+- GitHub Security Advisories and maintainer security pages (in clean-room
+  mode, do not search GitHub; open any GitHub-hosted page, including an
+  advisory or a maintainer security page, only at an exact URL obtained from
+  a directly reviewed non-GitHub authoritative source, per
+  `clean-room-generation.md`);
 - CISA Known Exploited Vulnerabilities and authoritative government guidance;
 - first-party commits, releases, tests, and affected-version statements;
 - original researcher disclosures with reproducible evidence; and

--- a/.agents/skills/author-saf-technique/references/clean-room-generation.md
+++ b/.agents/skills/author-saf-technique/references/clean-room-generation.md
@@ -51,12 +51,12 @@ before inspecting its substantive content.
 Do not use GitHub search or GitHub-scoped discovery in clean-room mode: domain
 filters and negative terms can still return the prohibited SAF repository and
 expose prior target prose in a result snippet. Open an exact GitHub advisory,
-release, or code URL only after its identifier and canonical URL were obtained
-from a directly reviewed, non-GitHub authoritative source such as NVD, CVE,
-CISA, a vendor bulletin, or a paper. Record that provenance in the source
-manifest. When a target is especially prone to search-result collisions,
-prefer direct authoritative URLs and first-party catalog endpoints over a
-general search operation.
+release, code, or maintainer security-page URL only after its identifier and
+canonical URL were obtained from a directly reviewed, non-GitHub authoritative
+source such as NVD, CVE, CISA, a vendor bulletin, or a paper. Record that
+provenance in the source manifest. When a target is especially prone to
+search-result collisions, prefer direct authoritative URLs and first-party
+catalog endpoints over a general search operation.
 
 ## Fresh-agent procedure
 
@@ -101,12 +101,29 @@ Create `research/techniques/SAF-TXXXX/clean-room-attestation.yml`. Record:
 - integration constraints; and
 - unresolved integrity concerns.
 
+`scripts/validate-technique-research.py` requires `prohibited_inputs` to
+contain each of the following strings verbatim, with the target ID
+substituted (matched case-insensitively as substrings); entries phrased only in
+this reference's descriptive wording fail validation:
+
+- `techniques/SAF-TXXXX/README.md`
+- `research/techniques/SAF-TXXXX/`
+- `techniques/SAF-TXXXX/detection-rule.yml`
+- `git history`
+- `pull request`
+- `previous conversation`
+
+The blank `research/templates/technique/clean-room-attestation.yml` carries
+these entries as a commented block; uncomment them, replacing the standard-mode
+placeholder, when setting `generation_mode: clean_room`.
+
 The attestation may pass only when prior-artifact access is `false`, its details
 are empty, the independent searches and reviewed source set are nonempty, the
 draft was frozen before integration, and there are no unresolved concerns.
 
 Before calculating freeze hashes, copy the independently generated bundle into
-an isolated mock repository and run the canonical research validator there. The
+an isolated mock repository and run the canonical research validator there in
+its default mode (without `--draft`). The
 mock may use newly created minimal framework, source-manifest, and repository-
 history records solely to exercise validation; it must not copy or open the real
 target or shared registries. A clean-room bundle is not freeze-ready if it uses
@@ -119,15 +136,30 @@ bundle-owned fields or files.
 
 ### Canonical clean-room handoff layout
 
-Every fresh-agent run must freeze the same merge-ready layout at
-`/private/tmp/saf-all-cleanroom/SAF-TXXXX/bundle/`:
+Every fresh-agent run must freeze the same merge-ready layout under a scratch
+root. The root is `$SAF_CLEANROOM_ROOT` when that variable is set and
+`${TMPDIR:-/tmp}/saf-all-cleanroom` otherwise, which resolves to
+`/tmp/saf-all-cleanroom` on Linux CI. Do not hardcode a platform-specific path
+such as `/private/tmp`. The resolved root must be an absolute path outside the
+repository checkout and outside every prohibited-input tree; if it is not,
+stop and set `$SAF_CLEANROOM_ROOT` explicitly. A first run freezes at
+`<root>/SAF-TXXXX/bundle/`. A retry or a no-research normalization re-freeze
+uses `<root>/SAF-TXXXX-rN/bundle/`, with `N` starting at 2 and incrementing
+per attempt. Create the root with `mkdir -p`, then create the attempt
+directory with a plain `mkdir` (no `-p`) so that it fails if the directory
+already exists; on collision take the next `N` rather than reusing, emptying,
+or writing into an existing directory, so a stale attempt or a concurrent run
+can never mix artifacts under one `FREEZE.sha256`. Record the resolved root,
+the attempt directory, and the reason for any re-freeze in
+`integration-notes.yml`, which is bundle-owned and already enumerates path
+joins. Use no other suffix for a freeze directory:
 
 ```text
 bundle/
   techniques/SAF-TXXXX/
   research/techniques/SAF-TXXXX/
   tests/SAF-TXXXX/                 # when tests are not technique-local
-  validation/                      # compact test and strict-validator proofs only
+  validation/                      # test and default-mode validator proofs
   source-manifest-fragment.yml
   framework-fragment.yml
   alignment-fragment.yml
@@ -140,14 +172,16 @@ bundle/
 `alignment-fragment.yml` must use the canonical alignment-ledger schema.
 `integration-notes.yml` must enumerate every synthetic tactic, neighbor,
 mitigation, source-ID, history-SHA, and path join that remains mechanical after
-freeze. Do not put a copied mock repository, source-acquisition corpus, cache,
-or validator dependency tree inside `bundle/`; retain those outside the bundle
-and record their hashes separately when needed.
+freeze, plus the freeze provenance: resolved scratch root, attempt directory,
+and the reason for any re-freeze. Do not put a copied mock repository, source-
+acquisition corpus, cache, or validator dependency tree inside `bundle/`;
+retain those outside the bundle and record their hashes separately when needed.
 
 `FREEZE.sha256` must contain one sorted `sha256  relative/path` line for every
 bundle-owned file except `FREEZE.sha256` itself. Verify it from the bundle root
 before handoff. Report the SHA-256 of `FREEZE.sha256`, the number of listed
-files, the detection result, and the strict isolated-validator result. A
+files, the detection result, and the isolated-validator result in default
+(non-`--draft`) mode. A
 different handoff layout is not canonical and must be normalized and re-frozen
 by a separate no-research agent before repository integration.
 

--- a/.agents/skills/author-saf-technique/references/methodology.md
+++ b/.agents/skills/author-saf-technique/references/methodology.md
@@ -209,7 +209,9 @@ omitted lead in the ledger.
 
 Name required telemetry and fields. Explain the analytic goal, logic,
 correlation window, false positives, blind spots, evasion opportunities, and
-tuning assumptions. Keep the executable analytic in `detection-rule.yml`.
+tuning assumptions. Keep the executable analytic in
+`techniques/SAF-TXXXX/detection-rule.yml`, beside the technique README rather
+than inside the research packet.
 
 When feasible, add deterministic tests covering true positives, true
 negatives, threshold or sequence boundaries, malformed or missing fields,

--- a/research/templates/technique/clean-room-attestation.yml
+++ b/research/templates/technique/clean-room-attestation.yml
@@ -16,6 +16,20 @@ allowed_inputs:
   - Clean-room generation was not requested for this scaffold.
 prohibited_inputs:
   - Clean-room generation was not requested for this scaffold.
+  # When converting this packet to generation_mode: clean_room, replace the
+  # entry above with the six entries below (uncomment them; the indented
+  # continuation lines stay valid YAML). scripts/validate-technique-research.py
+  # requires each of them to appear verbatim in this list in clean_room mode.
+  # - techniques/__TECHNIQUE_ID__/README.md, current or historical.
+  # - research/techniques/__TECHNIQUE_ID__/ packet files, ledgers, or source
+  #   lists.
+  # - techniques/__TECHNIQUE_ID__/detection-rule.yml, its tests, and test logs.
+  # - Git history, diffs, blame, stashes, commits, branches, or review comments
+  #   exposing prior target content.
+  # - Any pull request, issue, cached page, summary, or agent context
+  #   containing prior target content.
+  # - Any previous conversation or inherited context containing prior
+  #   technique content.
 
 independent_research:
   searches: []

--- a/scripts/validate-technique-research.py
+++ b/scripts/validate-technique-research.py
@@ -1526,7 +1526,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--draft",
         action="store_true",
-        help="Check structure without enforcing completion statuses",
+        help=(
+            "Relax strict-only completion and release checks: completion "
+            "statuses, hidden-trace coverage, untraced publishable prose, "
+            "saturation, publication permissions, and high-severity alignment "
+            "issues; the placeholder zero repository-history SHA is accepted. "
+            "Schema, cross-file joins, and core clean-room assertions are still "
+            "enforced. A draft PASS is not release validation."
+        ),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary

Aligns the `author-saf-technique` skill and the blank attestation template with what `scripts/validate-technique-research.py` actually enforces, and fixes one path and two portability problems in the clean-room instructions.

## What changed

- **Required `prohibited_inputs` fragments documented.** The validator requires six exact substrings in `prohibited_inputs` for `generation_mode: clean_room` (`validate-technique-research.py:519-530`). Four of them were absent from the skill, and `previous conversation` appeared nowhere in the skill or template, so an attestation written in the skill's own wording failed validation. `references/clean-room-generation.md` now lists the six strings verbatim, and `research/templates/technique/clean-room-attestation.yml` carries them as a commented block to uncomment when a packet is converted to `clean_room` (the standard-mode scaffold keeps its not-applicable placeholder, since those inputs are permitted in standard reruns).
- **Canonical paths corrected.** `SKILL.md` listed `traceability-ledger.yml` as a bare path among otherwise-complete canonical paths; it lives at `research/techniques/SAF-TXXXX/traceability-ledger.yml`. `references/methodology.md` now names `techniques/SAF-TXXXX/detection-rule.yml`, the one packet artifact outside the research packet.
- **GHSA search reconciled with clean-room mode.** `references/breach-and-vulnerability-research.md` mandated a GitHub Security Advisories search that `clean-room-generation.md` forbids; the bullet now carries the clean-room exception (open an exact advisory URL only after non-GitHub discovery).
- **Portable scratch root and a single retry convention.** The frozen-bundle path was hardcoded to `/private/tmp/...`, which does not exist on the `ubuntu-latest` CI runner. It is now `$SAF_CLEANROOM_ROOT`, defaulting to `${TMPDIR:-/tmp}/saf-all-cleanroom`, and must resolve to an absolute path outside the checkout. Attempt directories are created fail-closed (plain `mkdir`, next `-rN` on collision) so stale or concurrent attempts cannot mix under one `FREEZE.sha256`; freeze provenance is recorded in the bundle's `integration-notes.yml`. Retries and normalization re-freezes use `SAF-TXXXX-rN`; existing attestations had independently invented six different suffixes (`-normalized`, `-retry`, `-r2`, `-retry3`, `-validator`, `-isolated`).
- **"Strict validator" wording.** No `--strict` flag exists; strict checking is the default and `--draft` disables it. Wording now says "default (non-`--draft`) mode." The `--draft` help string said it only skipped "completion statuses"; it now states which strict-only checks it relaxes (including accepting the placeholder zero history SHA) and that schema, cross-file joins, and core clean-room assertions remain enforced.

## Testing

- `python3 -m unittest discover -s scripts -p "test_*.py"` — 15 tests, OK
- `validate-technique-research.py --all`, `validate-framework-model.py`, `generate-technique-catalog.py --check`, `validate-detection-registry.py`, `generate-detection-coverage.py --check`, `generate-mitigation-catalog.py --check` — all exit 0
- Reproduction of the original defect: in a scratch copy, rewriting `SAF-T1309`'s `prohibited_inputs` in the skill's verbatim wording fails with four `prohibited_inputs missing ...` errors; the unmodified packet passes.
- Template verified both ways in a scratch copy: a standard scaffold from `scripts/new-technique.py` produces zero clean-room errors; the same scaffold converted to `clean_room` per the documented procedure produces zero `prohibited_inputs missing` errors.
